### PR TITLE
[APB-3376][AO] add failoverStrategy for MongoDB connector to prevent intermittent failures

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,19 +23,18 @@ lazy val compileDeps = Seq(
   "uk.gov.hmrc" %% "domain" % "5.3.0",
   "com.github.blemale" %% "scaffeine" % "2.5.0",
   "uk.gov.hmrc" %% "agent-kenshoo-monitoring" % "3.4.0",
-  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.9.0-play-25",
-  "uk.gov.hmrc" %% "mongo-lock" % "6.6.0-play-25",
-  "org.typelevel" %% "cats" % "0.9.0",
-  "com.typesafe.akka" %% "akka-actor" % "2.4.14"
+  "uk.gov.hmrc" %% "simple-reactivemongo" % "7.12.0-play-25",
+  "uk.gov.hmrc" %% "mongo-lock" % "6.10.0-play-25",
+  "org.typelevel" %% "cats" % "0.9.0"
 )
 
 def testDeps(scope: String) = Seq(
   "uk.gov.hmrc" %% "hmrctest" % "3.4.0-play-25" % scope,
   "org.scalatest" %% "scalatest" % "3.0.5" % scope,
-  "org.mockito" % "mockito-core" % "2.23.4" % scope,
+  "org.mockito" % "mockito-core" % "2.24.0" % scope,
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % scope,
   "uk.gov.hmrc" %% "reactivemongo-test" % "4.6.0-play-25" % scope,
-  "com.github.tomakehurst" % "wiremock" % "2.18.0" % scope
+  "com.github.tomakehurst" % "wiremock" % "2.21.0" % scope
 )
 
 lazy val root = (project in file("."))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -156,6 +156,15 @@ Dev {
 
   mongodb {
     uri = "mongodb://localhost:27017/agent-client-relationships"
+
+    failoverStrategy {
+      initialDelayMsecs = 100
+      retries = 10
+      delay {
+        factor = 1.25
+        function = fibonacci
+      }
+    }
   }
 
   microservice.services {
@@ -193,6 +202,15 @@ Test {
 
   mongodb {
     uri = "mongodb://localhost:27017/agent-client-relationships"
+
+    failoverStrategy {
+      initialDelayMsecs = 100
+      retries = 10
+      delay {
+        factor = 1.25
+        function = fibonacci
+      }
+    }
   }
 
   microservice.services {
@@ -228,6 +246,15 @@ Prod {
 
   mongodb {
     uri = "mongodb://localhost:27017/agent-client-relationships"
+
+    failoverStrategy {
+      initialDelayMsecs = 100
+      retries = 10
+      delay {
+        factor = 1.25
+        function = fibonacci
+      }
+    }
   }
 
   microservice.services {

--- a/it/uk/gov/hmrc/agentrelationships/support/MongoApp.scala
+++ b/it/uk/gov/hmrc/agentrelationships/support/MongoApp.scala
@@ -1,7 +1,8 @@
 package uk.gov.hmrc.agentrelationships.support
 
 import org.scalatest.{BeforeAndAfterEach, Suite}
-import uk.gov.hmrc.mongo.{MongoSpecSupport, Awaiting => MongoAwaiting}
+import reactivemongo.api.FailoverStrategy
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport, Awaiting => MongoAwaiting}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
@@ -10,6 +11,16 @@ trait MongoApp extends MongoSpecSupport with ResetMongoBeforeTest {
   me: Suite =>
 
   protected def mongoConfiguration = Map("mongodb.uri" -> mongoUri)
+
+  override implicit lazy val mongoConnectorForTest: MongoConnector =
+    MongoConnector(mongoUri, Some(MongoApp.failoverStrategyForTest))
+}
+
+object MongoApp {
+
+  import scala.concurrent.duration._
+  val failoverStrategyForTest = FailoverStrategy(50.millis, 5, _ * 1.618)
+
 }
 
 trait ResetMongoBeforeTest extends BeforeAndAfterEach {


### PR DESCRIPTION
This PR follows a similar change made to the agent-client-authorisation. Both services instantiate scheduler eagerly and can suffer from the DB connection initialisation issue.