### PR TITLE
Correcting a fire-and-forget of DB update of the copy relationship record's 'syncToESStatus' field

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
@@ -123,9 +123,10 @@ class CreateRelationshipsService @Inject()(
       Logger(getClass).warn(
         s"Creating ES record failed for ${arn.value}, ${identifier.value} (${identifier.getClass.getName})",
         origExc)
-      updateEsSyncStatus(Failed)
-      if (failIfAllocateAgentInESFails) Future.failed(replacementExc)
-      else Future.successful(())
+      updateEsSyncStatus(Failed).flatMap { _ =>
+        if (failIfAllocateAgentInESFails) Future.failed(replacementExc)
+        else Future.successful(())
+      }
     }
 
     val recoverAgentUserRelationshipNotFound: PartialFunction[Throwable, Future[Unit]] = {


### PR DESCRIPTION
DB update of copy relationship record's 'syncToESStatus' field (when setting it to 'Failed' after a failed EACD enrolment call) was occuring in a fire-and-forget fashion. This DB update future is now included in the normal sequence of futures, so the DB update will finish by the time the request's response is returned.