### PR TITLE
 Removes throwing UpstreamErrorResponse in IFConnector

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
@@ -197,7 +197,6 @@ class RelationshipsController @Inject()(
               .createRelationship(arn, taxIdentifier, Set(), false, true)
               .map(_ => Created)
               .recover {
-                case upS: Upstream5xxResponse => throw upS
                 case NonFatal(ex) =>
                   logger.warn("Could not create relationship due to ", ex)
                   NotFound(toJson(ex.getMessage))

--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
@@ -199,7 +199,7 @@ class RelationshipsController @Inject()(
               .recover {
                 case NonFatal(ex) =>
                   logger.warn("Could not create relationship due to ", ex)
-                  NotFound(toJson(ex.getMessage))
+                  InternalServerError(toJson(ex.getMessage))
               }
           }
 
@@ -245,7 +245,7 @@ class RelationshipsController @Inject()(
                 case upS: Upstream5xxResponse => throw upS
                 case NonFatal(ex) =>
                   logger.warn("Could not delete relationship", ex)
-                  NotFound(toJson(ex.getMessage))
+                  InternalServerError(toJson(ex.getMessage))
               }
           }
         case Left(error) => Future.successful(BadRequest(error))

--- a/app/uk/gov/hmrc/agentclientrelationships/repository/DbUpdateStatus.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/repository/DbUpdateStatus.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.repository
+
+sealed trait DbUpdateStatus
+
+object DbUpdateStatus {
+  def convertDbUpdateStatus(updatedCount: Int): DbUpdateStatus =
+    if (updatedCount == 1) DbUpdateSucceeded else DbUpdateFailed
+}
+
+case object DbUpdateSucceeded extends DbUpdateStatus
+case object DbUpdateFailed extends DbUpdateStatus

--- a/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
@@ -99,8 +99,9 @@ class CreateRelationshipsService @Inject()(
     }
 
     (for {
-      _ <- updateEtmpSyncStatus(InProgress)
-      _ <- ifConnector.createAgentRelationship(identifier, arn)
+      _             <- updateEtmpSyncStatus(InProgress)
+      maybeResponse <- ifConnector.createAgentRelationship(identifier, arn)
+      if maybeResponse.nonEmpty
       _ = auditData.set("etmpRelationshipCreated", true)
       _ <- updateEtmpSyncStatus(Success)
     } yield ())

--- a/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.agentclientrelationships.audit.AuditData
 import uk.gov.hmrc.agentclientrelationships.config.AppConfig
 import uk.gov.hmrc.agentclientrelationships.connectors._
 import uk.gov.hmrc.agentclientrelationships.model.TypeOfEnrolment
+import uk.gov.hmrc.agentclientrelationships.repository.DbUpdateStatus.convertDbUpdateStatus
 import uk.gov.hmrc.agentclientrelationships.repository.SyncStatus._
 import uk.gov.hmrc.agentclientrelationships.repository.{SyncStatus => _, _}
 import uk.gov.hmrc.agentclientrelationships.support.{Monitoring, RelationshipNotFound}
@@ -57,7 +58,7 @@ class CreateRelationshipsService @Inject()(
     failIfAllocateAgentInESFails: Boolean)(
     implicit ec: ExecutionContext,
     hc: HeaderCarrier,
-    auditData: AuditData): Future[Option[Unit]] =
+    auditData: AuditData): Future[Option[DbUpdateStatus]] =
     lockService
       .tryLock(arn, identifier) {
 
@@ -65,33 +66,41 @@ class CreateRelationshipsService @Inject()(
         auditData.set("enrolmentDelegated", false)
         auditData.set("etmpRelationshipCreated", false)
 
-        def createRelationshipRecord: Future[Unit] = {
+        def createRelationshipRecord: Future[DbUpdateStatus] = {
           val identifierType = TypeOfEnrolment(identifier).identifierKey
           val record = RelationshipCopyRecord(arn.value, identifier.value, identifierType, Some(oldReferences))
           relationshipCopyRepository
             .create(record)
-            .map(_ => auditData.set("AgentDBRecord", true))
+            .map(count => {
+              auditData.set("AgentDBRecord", true)
+              convertDbUpdateStatus(count)
+            })
             .recoverWith {
               case NonFatal(ex) =>
                 logger.warn(
                   s"Inserting relationship record into mongo failed for ${arn.value}, ${identifier.value} (${identifier.getClass.getSimpleName})",
                   ex)
                 if (failIfCreateRecordFails) Future.failed(new Exception("RELATIONSHIP_CREATE_FAILED_DB"))
-                else Future.successful(())
+                else Future.successful(DbUpdateFailed)
             }
         }
 
         for {
-          _ <- createRelationshipRecord
-          _ <- createEtmpRecord(arn, identifier)
-          _ <- createEsRecord(arn, identifier, failIfAllocateAgentInESFails)
-        } yield ()
+          recordCreationStatus <- createRelationshipRecord
+          if recordCreationStatus == DbUpdateSucceeded
+          etmpRecordCreationStatus <- createEtmpRecord(arn, identifier)
+          if etmpRecordCreationStatus == DbUpdateSucceeded
+          esRecordCreationStatus <- createEsRecord(arn, identifier, failIfAllocateAgentInESFails)
+        } yield esRecordCreationStatus
       }
 
-  private def createEtmpRecord(
-    arn: Arn,
-    identifier: TaxIdentifier)(implicit ec: ExecutionContext, hc: HeaderCarrier, auditData: AuditData): Future[Unit] = {
-    val updateEtmpSyncStatus = relationshipCopyRepository.updateEtmpSyncStatus(arn, identifier, _: SyncStatus)
+  private def createEtmpRecord(arn: Arn, identifier: TaxIdentifier)(
+    implicit ec: ExecutionContext,
+    hc: HeaderCarrier,
+    auditData: AuditData): Future[DbUpdateStatus] = {
+    val updateEtmpSyncStatus = relationshipCopyRepository
+      .updateEtmpSyncStatus(arn, identifier, _: SyncStatus)
+      .map(convertDbUpdateStatus)
 
     val recoverWithException = (origExc: Throwable, replacementExc: Throwable) => {
       logger.warn(s"Creating ETMP record failed for ${arn.value}, $identifier due to: ${origExc.getMessage}", origExc)
@@ -99,12 +108,13 @@ class CreateRelationshipsService @Inject()(
     }
 
     (for {
-      _             <- updateEtmpSyncStatus(InProgress)
+      etmpSyncStatusInProgress <- updateEtmpSyncStatus(InProgress)
+      if etmpSyncStatusInProgress == DbUpdateSucceeded
       maybeResponse <- ifConnector.createAgentRelationship(identifier, arn)
       if maybeResponse.nonEmpty
       _ = auditData.set("etmpRelationshipCreated", true)
-      _ <- updateEtmpSyncStatus(Success)
-    } yield ())
+      etmpSyncStatusSuccess <- updateEtmpSyncStatus(Success)
+    } yield etmpSyncStatusSuccess)
       .recoverWith {
         case e @ Upstream5xxResponse(_, upstreamCode, reportAs, headers) =>
           recoverWithException(
@@ -119,48 +129,50 @@ class CreateRelationshipsService @Inject()(
   private def createEsRecord(arn: Arn, identifier: TaxIdentifier, failIfAllocateAgentInESFails: Boolean)(
     implicit ec: ExecutionContext,
     hc: HeaderCarrier,
-    auditData: AuditData): Future[Unit] = {
+    auditData: AuditData): Future[DbUpdateStatus] = {
 
-    val updateEsSyncStatus = relationshipCopyRepository.updateEsSyncStatus(arn, identifier, _: SyncStatus)
+    val updateEsSyncStatus = relationshipCopyRepository
+      .updateEsSyncStatus(arn, identifier, _: SyncStatus)
+      .map(convertDbUpdateStatus)
 
-    def logAndMaybeFail(origExc: Throwable, replacementExc: Throwable): Future[Unit] = {
+    def logAndMaybeFail(origExc: Throwable, replacementExc: Throwable): Future[DbUpdateStatus] = {
       logger.warn(
         s"Creating ES record failed for ${arn.value}, ${identifier.value} (${identifier.getClass.getName})",
         origExc)
       updateEsSyncStatus(Failed).flatMap { _ =>
         if (failIfAllocateAgentInESFails) Future.failed(replacementExc)
-        else Future.successful(())
+        else Future.successful(DbUpdateFailed)
       }
     }
 
-    val recoverAgentUserRelationshipNotFound: PartialFunction[Throwable, Future[Unit]] = {
+    val recoverAgentUserRelationshipNotFound: PartialFunction[Throwable, Future[DbUpdateStatus]] = {
       case RelationshipNotFound(errorCode) =>
         logger.warn(
           s"Creating ES record for ${arn.value}, ${identifier.value} (${identifier.getClass.getName}) " +
             s"not possible because of incomplete data: $errorCode")
-        updateEsSyncStatus(IncompleteInputParams)
+        updateEsSyncStatus(IncompleteInputParams).map(_ => DbUpdateFailed)
     }
 
-    val recoverUpstream5xx: PartialFunction[Throwable, Future[Unit]] = {
+    val recoverUpstream5xx: PartialFunction[Throwable, Future[DbUpdateStatus]] = {
       case e @ Upstream5xxResponse(_, upstreamCode, reportAs, headers) =>
         logAndMaybeFail(e, UpstreamErrorResponse("RELATIONSHIP_CREATE_FAILED_ES", upstreamCode, reportAs, headers))
     }
 
-    val recoverNonFatal: PartialFunction[Throwable, Future[Unit]] = {
+    val recoverNonFatal: PartialFunction[Throwable, Future[DbUpdateStatus]] = {
       case NonFatal(ex) =>
         logAndMaybeFail(ex, new Exception("RELATIONSHIP_CREATE_FAILED_ES"))
     }
 
-    def createDeleteRecord(record: DeleteRecord): Future[Unit] =
+    def createDeleteRecord(record: DeleteRecord): Future[DbUpdateStatus] =
       deleteRecordRepository
         .create(record)
-        .map(_ => ())
+        .map(convertDbUpdateStatus)
         .recover {
           case NonFatal(ex) =>
             logger.warn(
               s"Inserting delete record into mongo failed for ${arn.value}, ${identifier.value} (${identifier.getClass.getSimpleName})",
               ex)
-            ()
+            DbUpdateFailed
         }
 
     def removeDeleteRecord(arn: Arn, taxIdentifier: TaxIdentifier)(implicit ec: ExecutionContext): Future[Boolean] =
@@ -207,14 +219,15 @@ class CreateRelationshipsService @Inject()(
       } yield ()
 
     (for {
-      _              <- updateEsSyncStatus(InProgress)
+      esSyncStatusInProgress <- updateEsSyncStatus(InProgress)
+      if esSyncStatusInProgress == DbUpdateSucceeded
       maybeAgentUser <- agentUserService.getAgentAdminUserFor(arn)
       agentUser = maybeAgentUser.right.getOrElse(throw RelationshipNotFound("No admin agent user found"))
       _ <- deallocatePreviousRelationshipIfAny
       _ <- es.allocateEnrolmentToAgent(agentUser.groupId, agentUser.userId, identifier, agentUser.agentCode)
       _ = auditData.set("enrolmentDelegated", true)
-      _ <- updateEsSyncStatus(Success)
-    } yield ())
+      esSyncStatusSuccess <- updateEsSyncStatus(Success)
+    } yield esSyncStatusSuccess)
       .recoverWith(
         recoverAgentUserRelationshipNotFound
           .orElse(recoverUpstream5xx)
@@ -224,7 +237,7 @@ class CreateRelationshipsService @Inject()(
   def resumeRelationshipCreation(relationshipCopyRecord: RelationshipCopyRecord, arn: Arn, identifier: TaxIdentifier)(
     implicit ec: ExecutionContext,
     hc: HeaderCarrier,
-    auditData: AuditData): Future[Option[Unit]] =
+    auditData: AuditData): Future[Option[DbUpdateStatus]] =
     lockService
       .tryLock(arn, identifier) {
         def recoverEtmpRecord() = createEtmpRecord(arn, identifier)
@@ -234,9 +247,10 @@ class CreateRelationshipsService @Inject()(
         (relationshipCopyRecord.needToCreateEtmpRecord, relationshipCopyRecord.needToCreateEsRecord) match {
           case (true, true) =>
             for {
-              _ <- recoverEtmpRecord()
-              _ <- recoverEsRecord()
-            } yield ()
+              etmpStatus <- recoverEtmpRecord()
+              if etmpStatus == DbUpdateSucceeded
+              esStatus <- recoverEsRecord()
+            } yield esStatus
           case (false, true) =>
             recoverEsRecord()
           case (true, false) =>
@@ -247,7 +261,7 @@ class CreateRelationshipsService @Inject()(
           case (false, false) =>
             logger.warn(
               s"recoverRelationshipCreation called for ${arn.value}, ${identifier.value} (${identifier.getClass.getName}) when no recovery needed")
-            Future.successful(())
+            Future.successful(DbUpdateFailed)
         }
       }
 }

--- a/app/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipsService.scala
@@ -142,8 +142,9 @@ class DeleteRelationshipsService @Inject()(
     }
 
     (for {
-      _ <- updateEtmpSyncStatus(InProgress)
-      _ <- ifConnector.deleteAgentRelationship(taxIdentifier, arn)
+      _             <- updateEtmpSyncStatus(InProgress)
+      maybeResponse <- ifConnector.deleteAgentRelationship(taxIdentifier, arn)
+      if maybeResponse.nonEmpty
       _ = auditData.set("etmpRelationshipDeAuthorised", true)
       _ <- updateEtmpSyncStatus(Success)
     } yield ())

--- a/app/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipsService.scala
@@ -28,8 +28,9 @@ import uk.gov.hmrc.agentclientrelationships.auth.CurrentUser
 import uk.gov.hmrc.agentclientrelationships.config.AppConfig
 import uk.gov.hmrc.agentclientrelationships.connectors._
 import uk.gov.hmrc.agentclientrelationships.model.TypeOfEnrolment
+import uk.gov.hmrc.agentclientrelationships.repository.DbUpdateStatus.convertDbUpdateStatus
 import uk.gov.hmrc.agentclientrelationships.repository.SyncStatus._
-import uk.gov.hmrc.agentclientrelationships.repository.{DeleteRecord, DeleteRecordRepository}
+import uk.gov.hmrc.agentclientrelationships.repository.{DbUpdateFailed, DbUpdateStatus, DbUpdateSucceeded, DeleteRecord, DeleteRecordRepository}
 import uk.gov.hmrc.agentclientrelationships.support.{Monitoring, NoRequest, RelationshipNotFound, TaxIdentifierSupport}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, CgtRef, MtdItId, PptRef, Urn, Utr, Vrn}
 import uk.gov.hmrc.auth.core.AffinityGroup
@@ -71,10 +72,13 @@ class DeleteRelationshipsService @Inject()(
     auditData.set("enrolmentDeAllocated", false)
     auditData.set("etmpRelationshipDeAuthorised", false)
 
-    def createDeleteRecord(record: DeleteRecord): Future[Unit] =
+    def createDeleteRecord(record: DeleteRecord): Future[DbUpdateStatus] =
       deleteRecordRepository
         .create(record)
-        .map(_ => auditData.set("AgentDBRecord", true))
+        .map(count => {
+          auditData.set("AgentDBRecord", true)
+          convertDbUpdateStatus(count)
+        })
         .recoverWith {
           case NonFatal(ex) =>
             logger.warn(
@@ -92,10 +96,14 @@ class DeleteRelationshipsService @Inject()(
         headerCarrier = Some(hc),
         relationshipEndedBy = endedBy)
       for {
-        _ <- createDeleteRecord(record)
-        _ <- deleteEsRecord(arn, taxIdentifier)
-        _ <- deleteEtmpRecord(arn, taxIdentifier)
-        _ <- removeDeleteRecord(arn, taxIdentifier)
+        recordDeletionStatus <- createDeleteRecord(record)
+        if recordDeletionStatus == DbUpdateSucceeded
+        esRecordDeletionStatus <- deleteEsRecord(arn, taxIdentifier)
+        if esRecordDeletionStatus == DbUpdateSucceeded
+        etmpRecordDeletionStatus <- deleteEtmpRecord(arn, taxIdentifier)
+        if etmpRecordDeletionStatus == DbUpdateSucceeded
+        removed <- removeDeleteRecord(arn, taxIdentifier)
+        if removed
         _ <- setRelationshipEnded(arn, taxIdentifier, endedBy.getOrElse("HMRC"))
       } yield ()
     }
@@ -131,8 +139,10 @@ class DeleteRelationshipsService @Inject()(
   def deleteEtmpRecord(arn: Arn, taxIdentifier: TaxIdentifier)(
     implicit ec: ExecutionContext,
     hc: HeaderCarrier,
-    auditData: AuditData): Future[Unit] = {
-    val updateEtmpSyncStatus = deleteRecordRepository.updateEtmpSyncStatus(arn, taxIdentifier, _: SyncStatus)
+    auditData: AuditData): Future[DbUpdateStatus] = {
+    val updateEtmpSyncStatus = deleteRecordRepository
+      .updateEtmpSyncStatus(arn, taxIdentifier, _: SyncStatus)
+      .map(convertDbUpdateStatus)
 
     val recoverWithException = (origExc: Throwable, replacementExc: Throwable) => {
       logger.warn(
@@ -142,12 +152,13 @@ class DeleteRelationshipsService @Inject()(
     }
 
     (for {
-      _             <- updateEtmpSyncStatus(InProgress)
+      etmpSyncStatusInProgress <- updateEtmpSyncStatus(InProgress)
+      if etmpSyncStatusInProgress == DbUpdateSucceeded
       maybeResponse <- ifConnector.deleteAgentRelationship(taxIdentifier, arn)
       if maybeResponse.nonEmpty
       _ = auditData.set("etmpRelationshipDeAuthorised", true)
-      _ <- updateEtmpSyncStatus(Success)
-    } yield ())
+      etmpSyncStatusSuccess <- updateEtmpSyncStatus(Success)
+    } yield etmpSyncStatusSuccess)
       .recoverWith {
         case e @ Upstream5xxResponse(_, upstreamCode, reportAs, _) =>
           recoverWithException(e, UpstreamErrorResponse(s"RELATIONSHIP_DELETE_FAILED_IF", upstreamCode, reportAs))
@@ -161,11 +172,13 @@ class DeleteRelationshipsService @Inject()(
   def deleteEsRecord(arn: Arn, taxIdentifier: TaxIdentifier)(
     implicit ec: ExecutionContext,
     hc: HeaderCarrier,
-    auditData: AuditData): Future[Unit] = {
+    auditData: AuditData): Future[DbUpdateStatus] = {
 
-    val updateEsSyncStatus = deleteRecordRepository.updateEsSyncStatus(arn, taxIdentifier, _: SyncStatus)
+    val updateEsSyncStatus = deleteRecordRepository
+      .updateEsSyncStatus(arn, taxIdentifier, _: SyncStatus)
+      .map(convertDbUpdateStatus)
 
-    def logAndMaybeFail(origExc: Throwable, replacementExc: Throwable): Future[Unit] = {
+    def logAndMaybeFail(origExc: Throwable, replacementExc: Throwable): Future[DbUpdateStatus] = {
       logger.warn(
         s"De-allocating ES record failed for ${arn.value}, ${taxIdentifier.value} (${taxIdentifier.getClass.getName})",
         origExc)
@@ -173,39 +186,40 @@ class DeleteRelationshipsService @Inject()(
       Future.failed(replacementExc)
     }
 
-    lazy val recoverAgentUserRelationshipNotFound: PartialFunction[Throwable, Future[Unit]] = {
+    lazy val recoverAgentUserRelationshipNotFound: PartialFunction[Throwable, Future[DbUpdateStatus]] = {
       case RelationshipNotFound(errorCode) =>
         logger.warn(
           s"De-allocating ES record for ${arn.value}, ${taxIdentifier.value} (${taxIdentifier.getClass.getName}) " +
             s"not possible because of incomplete data: $errorCode")
-        updateEsSyncStatus(IncompleteInputParams)
+        updateEsSyncStatus(IncompleteInputParams).map(_ => DbUpdateFailed)
     }
 
-    lazy val recoverUpstream5xx: PartialFunction[Throwable, Future[Unit]] = {
+    lazy val recoverUpstream5xx: PartialFunction[Throwable, Future[DbUpdateStatus]] = {
       case e @ Upstream5xxResponse(_, upstreamCode, reportAs, _) =>
         logAndMaybeFail(e, UpstreamErrorResponse("RELATIONSHIP_DELETE_FAILED_ES", upstreamCode, reportAs))
     }
 
-    lazy val recoverUnauthorized: PartialFunction[Throwable, Future[Unit]] = {
+    lazy val recoverUnauthorized: PartialFunction[Throwable, Future[DbUpdateStatus]] = {
       case ex: UpstreamErrorResponse if ex.statusCode == 401 =>
         logAndMaybeFail(ex, ex)
     }
 
-    lazy val recoverNonFatal: PartialFunction[Throwable, Future[Unit]] = {
+    lazy val recoverNonFatal: PartialFunction[Throwable, Future[DbUpdateStatus]] = {
       case NonFatal(ex) =>
         logAndMaybeFail(ex, new Exception("RELATIONSHIP_DELETE_FAILED_ES"))
     }
 
     (for {
-      _              <- updateEsSyncStatus(InProgress)
+      esSyncStatusInProgress <- updateEsSyncStatus(InProgress)
+      if esSyncStatusInProgress == DbUpdateSucceeded
       maybeAgentUser <- agentUserService.getAgentAdminUserFor(arn)
       agentUser = maybeAgentUser.fold(error => throw RelationshipNotFound(error), identity)
       _ <- checkService
             .checkForRelationship(taxIdentifier, agentUser)
             .flatMap(_ => es.deallocateEnrolmentFromAgent(agentUser.groupId, taxIdentifier))
       _ = auditData.set("enrolmentDeAllocated", true)
-      _ <- updateEsSyncStatus(Success)
-    } yield ()).recoverWith(
+      esSyncStatusSuccess <- updateEsSyncStatus(Success)
+    } yield esSyncStatusSuccess).recoverWith(
       recoverAgentUserRelationshipNotFound
         .orElse(recoverUpstream5xx)
         .orElse(recoverUnauthorized)

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,6 @@ lazy val root = (project in file("."))
     IntegrationTest / parallelExecution := false
   )
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
-  .disablePlugins(JUnitXmlReportPlugin)
 
 inConfig(IntegrationTest)(scalafmtCoreSettings)
 

--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val root = (project in file("."))
     organization := "uk.gov.hmrc",
     PlayKeys.playDefaultPort := 9434,
     majorVersion := 0,
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.15",
     scalacOptions ++= Seq(
       "-Yrangepos",
       "-Xfatal-warnings",
@@ -65,8 +65,8 @@ lazy val root = (project in file("."))
     resolvers += "HMRC-local-artefacts-maven" at "https://artefacts.tax.service.gov.uk/artifactory/hmrc-releases-local",
     libraryDependencies ++= tmpMacWorkaround() ++ compileDeps ++ testDeps("test") ++ testDeps("it"),
     libraryDependencies ++= Seq(
-      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.4.4" cross CrossVersion.full),
-      "com.github.ghik" % "silencer-lib" % "1.4.4" % Provided cross CrossVersion.full
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.8" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.7.8" % Provided cross CrossVersion.full
     ),
     publishingSettings,
     scoverageSettings,

--- a/it/uk/gov/hmrc/agentclientrelationships/connectors/MappingConnectorSpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/connectors/MappingConnectorSpec.scala
@@ -6,13 +6,11 @@ import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentclientrelationships.config.AppConfig
-import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.agentclientrelationships.stubs.{DataStreamStub, MappingStubs}
-import uk.gov.hmrc.agentclientrelationships.support.{MetricTestSupport, WireMockSupport}
+import uk.gov.hmrc.agentclientrelationships.support.{MetricTestSupport, UnitSpec, WireMockSupport}
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.domain.{AgentCode, SaAgentReference}
-import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
-import uk.gov.hmrc.http.HttpClient
-import uk.gov.hmrc.agentclientrelationships.support.UnitSpec
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -76,22 +74,22 @@ class MappingConnectorSpec
       await(mappingConnector.getSaAgentReferencesFor(arn)) shouldBe references
     }
 
-    "fail when arn is unknown in " in {
+    "return empty sequence when arn is unknown in " in {
       givenArnIsUnknownFor(arn)
       givenAuditConnector()
-      an[Exception] should be thrownBy await(mappingConnector.getSaAgentReferencesFor(arn))
+      await(mappingConnector.getSaAgentReferencesFor(arn)) shouldBe empty
     }
 
-    "fail when mapping service is unavailable" in {
+    "return empty sequence when mapping service is unavailable" in {
       givenServiceReturnsServiceUnavailable()
       givenAuditConnector()
-      an[UpstreamErrorResponse] should be thrownBy await(mappingConnector.getSaAgentReferencesFor(arn))
+      await(mappingConnector.getSaAgentReferencesFor(arn)) shouldBe empty
     }
 
-    "fail when mapping service is throwing errors" in {
+    "return empty sequence when mapping service is throwing errors" in {
       givenServiceReturnsServerError()
       givenAuditConnector()
-      an[Exception] should be thrownBy await(mappingConnector.getSaAgentReferencesFor(arn))
+      await(mappingConnector.getSaAgentReferencesFor(arn)) shouldBe empty
     }
 
     "record metrics for Mappings" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
@@ -224,7 +224,7 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
     "return 403 for a client with a mismatched CgtRef" in {
@@ -513,8 +513,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenIFReturnsServiceUnavailable()
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -533,8 +533,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
@@ -171,17 +171,17 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       result.status shouldBe 201
     }
 
-    "return 503 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(cgtRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
-    "return 502 when ES8 is unavailable" in {
+    "return 404 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(cgtRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -197,8 +197,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 when DES is unavailable" in {
@@ -384,8 +384,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -412,8 +412,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
@@ -201,7 +201,7 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
-    "return 502 when DES is unavailable" in {
+    "return 404 when DES is unavailable" in {
       givenUserIsSubscribedClient(cgtRef)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -210,8 +210,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 if DES returns 404" in {
@@ -224,7 +224,7 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
     "return 403 for a client with a mismatched CgtRef" in {
@@ -513,8 +513,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenIFReturnsServiceUnavailable()
       }
 
-      "return 502" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 503
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -533,8 +533,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerCGTISpec.scala
@@ -171,17 +171,17 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       result.status shouldBe 201
     }
 
-    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 500 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(cgtRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
     }
 
-    "return 404 when ES8 is unavailable" in {
+    "return 500 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(cgtRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -197,11 +197,11 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 when DES is unavailable" in {
+    "return 500 when DES is unavailable" in {
       givenUserIsSubscribedClient(cgtRef)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -210,11 +210,11 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 if DES returns 404" in {
+    "return 500 if DES returns 404" in {
       givenUserIsSubscribedClient(cgtRef)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -223,7 +223,7 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
@@ -384,8 +384,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -412,8 +412,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -513,8 +513,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenIFReturnsServiceUnavailable()
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -533,8 +533,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -581,8 +581,8 @@ class RelationshipsControllerCGTISpec extends RelationshipsBaseControllerISpec {
         //givenPrincipalGroupIdNotExistsFor(cgtRef)
       }
 
-      "return 404" in new StubsForScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
@@ -952,8 +952,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
         verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
@@ -981,8 +981,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
         verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
@@ -1100,8 +1100,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
         verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
       }
 
@@ -1123,8 +1123,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
         verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
       }
 
@@ -1315,8 +1315,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
         verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
@@ -1345,8 +1345,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
         verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
@@ -1477,8 +1477,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
         verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
       }
 
@@ -1631,17 +1631,17 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       result.status shouldBe 201
     }
 
-    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 500 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(mtdItId)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
     }
 
-    "return 404 when ES8 is unavailable" in {
+    "return 500 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(mtdItId)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -1657,11 +1657,11 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 when DES is unavailable" in {
+    "return 500 when DES is unavailable" in {
       givenUserIsSubscribedClient(mtdItId)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -1670,11 +1670,11 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 if IF returns 404" in {
+    "return 500 if IF returns 404" in {
       givenUserIsSubscribedClient(mtdItId)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -1683,7 +1683,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
@@ -488,8 +488,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         'clientIdentifier (mtdItId.value),
         'clientIdentifierType (mtdItIdType),
         'references (Some(Set(SaRef(SaAgentReference("foo"))))),
-        'syncToETMPStatus (Some(SyncStatus.Failed)),
-        'syncToESStatus (None)
+        'syncToETMPStatus (Some(SyncStatus.Success)),
+        'syncToESStatus (Some(SyncStatus.Success))
       )
 
     }
@@ -1100,9 +1100,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 503" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 503
-        verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
+        verifyDeleteRecordNotExists
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1123,9 +1123,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
-        verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
+        verifyDeleteRecordNotExists
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1477,9 +1477,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
-        verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
+        verifyDeleteRecordNotExists
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1661,7 +1661,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
-    "return 502 when DES is unavailable" in {
+    "return 404 when DES is unavailable" in {
       givenUserIsSubscribedClient(mtdItId)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -1670,8 +1670,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 if IF returns 404" in {
@@ -1684,7 +1684,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
     "return 403 for a client with a mismatched MtdItId" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
@@ -73,7 +73,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
 
       val result = doRequest
       result.status shouldBe 404
-      (result.json \ "code").as[String] shouldBe "UNKNOWN_ARN"
+      (result.json \ "code").as[String] shouldBe "RELATIONSHIP_NOT_FOUND"
     }
 
     "return 404 when agent code is not found in ugs" in {
@@ -86,7 +86,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
 
       val result = doRequest
       result.status shouldBe 404
-      (result.json \ "code").as[String] shouldBe "MISSING_GROUP"
+      (result.json \ "code").as[String] shouldBe "RELATIONSHIP_NOT_FOUND"
     }
 
     "return 404 when delete is pending" in {
@@ -134,7 +134,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
 
       val result = doRequest
       result.status shouldBe 404
-      (result.json \ "code").as[String] shouldBe "NO_ADMIN_USER"
+      (result.json \ "code").as[String] shouldBe "RELATIONSHIP_NOT_FOUND"
 
       await(deleteRecordRepository.remove(arn, mtdItId))
     }
@@ -600,7 +600,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       (result.json \ "code").as[String] shouldBe "UNKNOWN_ARN"
     }
 
-    "return 502 when mapping service is unavailable" in {
+    "return 404 when mapping service is unavailable" in {
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
       givenDelegatedGroupIdsNotExistForMtdItId(mtdItId)
@@ -610,7 +610,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       givenAdminUser("foo", "any")
 
       val result = doRequest
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
   }
 
@@ -681,7 +681,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       (result.json \ "code").as[String] shouldBe "RELATIONSHIP_NOT_FOUND"
     }
 
-    "return 5xx mapping is unavailable" in {
+    "return 404 when mapping is unavailable" in {
       getAgentRecordForClient(arn)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -691,7 +691,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       givenServiceReturnsServiceUnavailable()
 
       val result = doRequest
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
     "return 404 when agent not allocated to client in es and also cesa mapping not found" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
@@ -952,9 +952,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
-        verifyDeleteRecordNotExists
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
+        verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -981,9 +981,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
-        verifyDeleteRecordNotExists
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
+        verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1315,9 +1315,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
-        verifyDeleteRecordNotExists
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
+        verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1345,9 +1345,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
-        verifyDeleteRecordNotExists
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
+        verifyDeleteRecordHasStatuses(None, Some(SyncStatus.IncompleteInputParams))
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1631,17 +1631,17 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       result.status shouldBe 201
     }
 
-    "return 502 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(mtdItId)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
-    "return 502 when ES8 is unavailable" in {
+    "return 404 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(mtdItId)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -1657,8 +1657,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 when DES is unavailable" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSAISpec.scala
@@ -488,8 +488,8 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         'clientIdentifier (mtdItId.value),
         'clientIdentifierType (mtdItIdType),
         'references (Some(Set(SaRef(SaAgentReference("foo"))))),
-        'syncToETMPStatus (Some(SyncStatus.Success)),
-        'syncToESStatus (Some(SyncStatus.Success))
+        'syncToETMPStatus (Some(SyncStatus.Failed)),
+        'syncToESStatus (None)
       )
 
     }
@@ -1100,9 +1100,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
-        verifyDeleteRecordNotExists
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
+        verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1123,9 +1123,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
-        verifyDeleteRecordNotExists
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
+        verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1477,9 +1477,9 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
-        verifyDeleteRecordNotExists
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
+        verifyDeleteRecordHasStatuses(Some(SyncStatus.Failed), Some(SyncStatus.Success))
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1684,7 +1684,7 @@ class RelationshipsControllerITSAISpec extends RelationshipsBaseControllerISpec 
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
     "return 403 for a client with a mismatched MtdItId" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
@@ -223,7 +223,7 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
     "return 403 for a client with a mismatched PptRef" in {
@@ -513,8 +513,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -533,8 +533,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
@@ -170,17 +170,17 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       result.status shouldBe 201
     }
 
-    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 500 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(pptRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
     }
 
-    "return 404 when ES8 is unavailable" in {
+    "return 500 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(pptRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -196,11 +196,11 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 when IF is unavailable" in {
+    "return 500 when IF is unavailable" in {
       givenUserIsSubscribedClient(pptRef)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -209,11 +209,11 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 if IF returns 404" in {
+    "return 500 if IF returns 404" in {
       givenUserIsSubscribedClient(pptRef)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -222,7 +222,7 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
@@ -384,8 +384,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -412,8 +412,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -513,8 +513,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -533,8 +533,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -568,8 +568,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         //givenPrincipalGroupIdNotExistsFor(pptRef)
       }
 
-      "return 404" in new StubsForScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
@@ -170,17 +170,17 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       result.status shouldBe 201
     }
 
-    "return 503 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(pptRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
-    "return 502 when ES8 is unavailable" in {
+    "return 404 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(pptRef)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -196,8 +196,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 when IF is unavailable" in {
@@ -384,8 +384,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -412,8 +412,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerPPTISpec.scala
@@ -200,7 +200,7 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
-    "return 502 when IF is unavailable" in {
+    "return 404 when IF is unavailable" in {
       givenUserIsSubscribedClient(pptRef)
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
@@ -209,8 +209,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 if IF returns 404" in {
@@ -223,7 +223,7 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
     "return 403 for a client with a mismatched PptRef" in {
@@ -513,8 +513,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 502" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 503
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -533,8 +533,8 @@ class RelationshipsControllerPPTISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
@@ -198,15 +198,15 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
       result.status shouldBe 201
     }
 
-    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 500 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(utr)
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
     }
 
-    "return 404 when ES8 is unavailable" in {
+    "return 500 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(utr)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -222,27 +222,27 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 when DES is unavailable" in {
+    "return 500 when DES is unavailable" in {
       givenUserIsSubscribedClient(utr)
       givenDelegatedGroupIdsNotExistForTrust(utr)
       givenDesReturnsServiceUnavailable()
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 if DES returns 404" in {
+    "return 500 if DES returns 404" in {
       givenUserIsSubscribedClient(utr)
       givenDelegatedGroupIdsNotExistForTrust(utr)
       givenAgentCanNotBeAllocatedInIF(status = 404)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
@@ -403,8 +403,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -431,8 +431,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -532,8 +532,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -552,8 +552,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -602,8 +602,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenDelegatedGroupIdRequestFailsWith(404)
       }
 
-      "return 404" in new StubsForScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
@@ -243,7 +243,7 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
     "return 403 for a client with a mismatched MtdItId" in {
@@ -532,8 +532,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -552,8 +552,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
@@ -198,15 +198,15 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
       result.status shouldBe 201
     }
 
-    "return 502 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(utr)
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
-    "return 502 when ES8 is unavailable" in {
+    "return 404 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(utr)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -222,8 +222,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 when DES is unavailable" in {
@@ -403,8 +403,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -431,8 +431,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustISpec.scala
@@ -226,14 +226,14 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
       (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
-    "return 502 when DES is unavailable" in {
+    "return 404 when DES is unavailable" in {
       givenUserIsSubscribedClient(utr)
       givenDelegatedGroupIdsNotExistForTrust(utr)
       givenDesReturnsServiceUnavailable()
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 if DES returns 404" in {
@@ -243,7 +243,7 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
     "return 403 for a client with a mismatched MtdItId" in {
@@ -532,8 +532,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 502" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 503
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -552,8 +552,8 @@ class RelationshipsControllerTrustISpec extends RelationshipsBaseControllerISpec
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
@@ -184,15 +184,15 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
       result.status shouldBe 201
     }
 
-    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 500 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(urn)
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
     }
 
-    "return 404 when ES8 is unavailable" in {
+    "return 500 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(urn)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -208,27 +208,27 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 when IF is unavailable" in {
+    "return 500 when IF is unavailable" in {
       givenUserIsSubscribedClient(urn)
       givenDelegatedGroupIdsNotExistForTrustNT(urn)
       givenDesReturnsServiceUnavailable()
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 if IF returns 404" in {
+    "return 500 if IF returns 404" in {
       givenUserIsSubscribedClient(urn)
       givenDelegatedGroupIdsNotExistForTrustNT(urn)
       givenAgentCanNotBeAllocatedInIF(status = 404)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
@@ -389,8 +389,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -417,8 +417,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -518,8 +518,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -538,8 +538,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -588,8 +588,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenDelegatedGroupIdRequestFailsWith(404)
       }
 
-      "return 404" in new StubsForScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
@@ -184,15 +184,15 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
       result.status shouldBe 201
     }
 
-    "return 502 when ES1 is unavailable" in new StubsForThisScenario {
+    "return 404 when ES1 is unavailable" in new StubsForThisScenario {
       givenUserIsSubscribedClient(urn)
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
-    "return 502 when ES8 is unavailable" in {
+    "return 404 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(urn)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo(groupId = "foo", agentCode = "bar")
@@ -208,8 +208,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 when IF is unavailable" in {
@@ -389,8 +389,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -417,8 +417,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
@@ -229,7 +229,7 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
     "return 403 for a client with a mismatched MtdItId" in {
@@ -518,8 +518,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -538,8 +538,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerTrustNTISpec.scala
@@ -212,14 +212,14 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
       (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
-    "return 502 when IF is unavailable" in {
+    "return 404 when IF is unavailable" in {
       givenUserIsSubscribedClient(urn)
       givenDelegatedGroupIdsNotExistForTrustNT(urn)
       givenDesReturnsServiceUnavailable()
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 if IF returns 404" in {
@@ -229,7 +229,7 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
     "return 403 for a client with a mismatched MtdItId" in {
@@ -518,8 +518,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenDesReturnsServiceUnavailable()
       }
 
-      "return 502" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 503
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -538,8 +538,8 @@ class RelationshipsControllerTrustNTISpec extends RelationshipsBaseControllerISp
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
@@ -719,8 +719,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -747,8 +747,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -848,8 +848,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenIFReturnsServiceUnavailable()
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -868,8 +868,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -918,8 +918,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenDelegatedGroupIdRequestFailsWith(404)
       }
 
-      "return 404" in new StubsForScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 500" in new StubsForScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 500
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForScenario {
@@ -999,7 +999,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
     }
 
 
-    "return 404 when ES1 is unavailable" in {
+    "return 500 when ES1 is unavailable" in {
       givenUserIsSubscribedClient(vrn)
       givenPrincipalUser(arn, "foo")
       givenDelegatedGroupIdsExistForMtdVatId(vrn)
@@ -1014,10 +1014,10 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
     }
 
-    "return 404 when ES8 is unavailable" in {
+    "return 500 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(vrn)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo("foo", "bar")
@@ -1034,11 +1034,11 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         agentCode = "bar")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 when DES is unavailable" in {
+    "return 500 when DES is unavailable" in {
       givenUserIsSubscribedClient(vrn)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo("foo", "bar")
@@ -1047,11 +1047,11 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "message").asOpt[String] shouldBe None
     }
 
-    "return 404 if DES returns 404" in {
+    "return 500 if DES returns 404" in {
       givenUserIsSubscribedClient(vrn)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo("foo", "bar")
@@ -1060,7 +1060,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "user1")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 404
+      result.status shouldBe 500
       (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
@@ -719,8 +719,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -747,8 +747,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenAdminUser("foo", "any")
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -999,7 +999,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
     }
 
 
-    "return 502 when ES1 is unavailable" in {
+    "return 404 when ES1 is unavailable" in {
       givenUserIsSubscribedClient(vrn)
       givenPrincipalUser(arn, "foo")
       givenDelegatedGroupIdsExistForMtdVatId(vrn)
@@ -1014,10 +1014,10 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       givenDelegatedGroupIdRequestFailsWith(503)
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
-    "return 502 when ES8 is unavailable" in {
+    "return 404 when ES8 is unavailable" in {
       givenUserIsSubscribedClient(vrn)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo("foo", "bar")
@@ -1034,8 +1034,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         agentCode = "bar")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 when DES is unavailable" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
@@ -353,8 +353,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         'clientIdentifier (vrn.value),
         'clientIdentifierType (mtdVatIdType),
         'references (Some(Set(VatRef(AgentCode(oldAgentCode))))),
-        'syncToETMPStatus (Some(SyncStatus.Success)),
-        'syncToESStatus (Some(SyncStatus.Success))
+        'syncToETMPStatus (Some(SyncStatus.Failed)),
+        'syncToESStatus (None)
       )
     }
 
@@ -848,8 +848,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenIFReturnsServiceUnavailable()
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -868,8 +868,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 204" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 204
+      "return 404" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 404
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1061,7 +1061,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
     }
 
     "return 403 for a client with a mismatched Vrn" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
@@ -512,7 +512,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       (result.json \ "code").as[String] shouldBe "UNKNOWN_ARN"
     }
 
-    "return 502 when mapping service is unavailable" in {
+    "return 404 when mapping service is unavailable" in {
       givenPrincipalUser(arn, "foo")
       givenGroupInfo("foo", "bar")
       givenDelegatedGroupIdsNotExistForMtdVatId(vrn)
@@ -521,7 +521,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doRequest
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
   }
 
@@ -548,12 +548,12 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       (result.json \ "code").as[String] shouldBe "RELATIONSHIP_NOT_FOUND"
     }
 
-    "return 5xx mapping is unavailable" in {
+    "return 404 when mapping is unavailable" in {
       givenAgentIsAllocatedAndAssignedToClientForHMCEVATDECORG(vrn, "foo")
       givenServiceReturnsServiceUnavailable()
 
       val result = doRequest
-      result.status shouldBe 503
+      result.status shouldBe 404
     }
 
     "return 200 when agent credentials unknown but relationship exists in mapping" in {

--- a/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerVATISpec.scala
@@ -353,8 +353,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         'clientIdentifier (vrn.value),
         'clientIdentifierType (mtdVatIdType),
         'references (Some(Set(VatRef(AgentCode(oldAgentCode))))),
-        'syncToETMPStatus (Some(SyncStatus.Failed)),
-        'syncToESStatus (None)
+        'syncToETMPStatus (Some(SyncStatus.Success)),
+        'syncToESStatus (Some(SyncStatus.Success))
       )
     }
 
@@ -848,8 +848,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenIFReturnsServiceUnavailable()
       }
 
-      "return 502" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 503
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -868,8 +868,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
         givenAgentCanNotBeDeallocatedInIF(status = 404)
       }
 
-      "return 404" in new StubsForThisScenario {
-        doAgentDeleteRequest(requestPath).status shouldBe 404
+      "return 204" in new StubsForThisScenario {
+        doAgentDeleteRequest(requestPath).status shouldBe 204
       }
 
       "not send the audit event ClientRemovedAgentServiceAuthorisation" in new StubsForThisScenario {
@@ -1038,7 +1038,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
-    "return 502 when DES is unavailable" in {
+    "return 404 when DES is unavailable" in {
       givenUserIsSubscribedClient(vrn)
       givenPrincipalUser(arn, "foo", userId = "user1")
       givenGroupInfo("foo", "bar")
@@ -1047,8 +1047,8 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
       givenAdminUser("foo", "any")
 
       val result = doAgentPutRequest(requestPath)
-      result.status shouldBe 503
-      (result.json \ "message").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      result.status shouldBe 404
+      (result.json \ "message").asOpt[String] shouldBe None
     }
 
     "return 404 if DES returns 404" in {
@@ -1061,7 +1061,7 @@ class RelationshipsControllerVATISpec extends RelationshipsBaseControllerISpec {
 
       val result = doAgentPutRequest(requestPath)
       result.status shouldBe 404
-      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_IF")
+      (result.json \ "code").asOpt[String] shouldBe Some("RELATIONSHIP_CREATE_FAILED_ES")
     }
 
     "return 403 for a client with a mismatched Vrn" in {

--- a/test/uk/gov/hmrc/agentclientrelationships/repository/FakeDeleteRecordRepository.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/repository/FakeDeleteRecordRepository.scala
@@ -49,23 +49,25 @@ class FakeDeleteRecordRepository extends DeleteRecordRepository {
   }
 
   override def updateEtmpSyncStatus(arn: Arn, identifier: TaxIdentifier, status: SyncStatus)(
-    implicit ec: ExecutionContext): Future[Unit] = {
+    implicit ec: ExecutionContext): Future[Int] = {
     val maybeValue: Option[DeleteRecord] = data.get(arn.value + identifier.value)
     Future.successful(
-      if (maybeValue.isDefined)
+      if (maybeValue.isDefined) {
         data(arn.value + identifier.value) = maybeValue.get.copy(syncToETMPStatus = Some(status))
-      else
+        1
+      } else
         throw new IllegalArgumentException(s"Unexpected arn and identifier $arn, $identifier"))
 
   }
 
   def updateEsSyncStatus(arn: Arn, identifier: TaxIdentifier, status: SyncStatus)(
-    implicit ec: ExecutionContext): Future[Unit] = {
+    implicit ec: ExecutionContext): Future[Int] = {
     val maybeValue: Option[DeleteRecord] = data.get(arn.value + identifier.value)
     Future.successful(
-      if (maybeValue.isDefined)
+      if (maybeValue.isDefined) {
         data(arn.value + identifier.value) = maybeValue.get.copy(syncToESStatus = Some(status))
-      else
+        1
+      } else
         throw new IllegalArgumentException(s"Unexpected arn and identifier $arn, $identifier"))
   }
 

--- a/test/uk/gov/hmrc/agentclientrelationships/repository/FakeRelationshipCopyRecordRepository.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/repository/FakeRelationshipCopyRecordRepository.scala
@@ -26,6 +26,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class FakeRelationshipCopyRecordRepository extends RelationshipCopyRecordRepository {
   private val data: mutable.Map[String, RelationshipCopyRecord] = mutable.Map()
+  private val UPDATED_RECORD_COUNT = 1
 
   override def create(record: RelationshipCopyRecord)(implicit ec: ExecutionContext): Future[Int] =
     findBy(Arn(record.arn), MtdItId(record.clientIdentifier)).map(result => {
@@ -48,10 +49,11 @@ class FakeRelationshipCopyRecordRepository extends RelationshipCopyRecordReposit
   }
 
   override def updateEtmpSyncStatus(arn: Arn, identifier: TaxIdentifier, status: SyncStatus)(
-    implicit ec: ExecutionContext): Future[Unit] = {
+    implicit ec: ExecutionContext): Future[Int] = {
     val maybeValue: Option[RelationshipCopyRecord] = data.get(arn.value + identifier.value)
     Future.successful(if (maybeValue.isDefined) {
       data(arn.value + identifier.value) = maybeValue.get.copy(syncToETMPStatus = Some(status))
+      UPDATED_RECORD_COUNT
     } else {
       throw new IllegalArgumentException(s"Unexpected arn and identifier $arn, $identifier")
     })
@@ -59,10 +61,11 @@ class FakeRelationshipCopyRecordRepository extends RelationshipCopyRecordReposit
   }
 
   def updateEsSyncStatus(arn: Arn, identifier: TaxIdentifier, status: SyncStatus)(
-    implicit ec: ExecutionContext): Future[Unit] = {
+    implicit ec: ExecutionContext): Future[Int] = {
     val maybeValue: Option[RelationshipCopyRecord] = data.get(arn.value + identifier.value)
     Future.successful(if (maybeValue.isDefined) {
       data(arn.value + identifier.value) = maybeValue.get.copy(syncToESStatus = Some(status))
+      UPDATED_RECORD_COUNT
     } else {
       throw new IllegalArgumentException(s"Unexpected arn and identifier $arn, $identifier")
     })

--- a/test/uk/gov/hmrc/agentclientrelationships/services/CheckAndCopyRelationshipServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/services/CheckAndCopyRelationshipServiceSpec.scala
@@ -1465,7 +1465,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
   private def relationshipWillBeCreated(identifier: TaxIdentifier): OngoingStubbing[Future[Unit]] = {
     when(ifConnector.createAgentRelationship(eqs(identifier), eqs(arn))(eqs(hc), eqs(ec)))
-      .thenReturn(Future successful RegistrationRelationshipResponse("processing date"))
+      .thenReturn(Future successful Some(RegistrationRelationshipResponse("processing date")))
     when(
       es.allocateEnrolmentToAgent(eqs(agentGroupId), eqs(agentUserId), eqs(identifier), eqs(agentCodeForAsAgent))(
         eqs(hc),
@@ -1479,16 +1479,16 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
   private def metricsStub(): OngoingStubbing[MetricRegistry] =
     when(metrics.defaultRegistry).thenReturn(new MetricRegistry)
 
-  def verifyEtmpRecordCreated(): Future[RegistrationRelationshipResponse] =
+  def verifyEtmpRecordCreated(): Future[Option[RegistrationRelationshipResponse]] =
     verify(ifConnector).createAgentRelationship(eqs(mtdItId), eqs(arn))(eqs(hc), eqs(ec))
 
-  def verifyEtmpRecordNotCreated(): Future[RegistrationRelationshipResponse] =
+  def verifyEtmpRecordNotCreated(): Future[Option[RegistrationRelationshipResponse]] =
     verify(ifConnector, never()).createAgentRelationship(eqs(mtdItId), eqs(arn))(eqs(hc), eqs(ec))
 
-  def verifyEtmpRecordCreatedForMtdVat(): Future[RegistrationRelationshipResponse] =
+  def verifyEtmpRecordCreatedForMtdVat(): Future[Option[RegistrationRelationshipResponse]] =
     verify(ifConnector).createAgentRelationship(eqs(vrn), eqs(arn))(eqs(hc), eqs(ec))
 
-  def verifyEtmpRecordNotCreatedForMtdVat(): Future[RegistrationRelationshipResponse] =
+  def verifyEtmpRecordNotCreatedForMtdVat(): Future[Option[RegistrationRelationshipResponse]] =
     verify(ifConnector, never()).createAgentRelationship(eqs(vrn), eqs(arn))(eqs(hc), eqs(ec))
 
   def verifyEsRecordCreated(): Future[Unit] =

--- a/test/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipServiceSpec.scala
@@ -495,7 +495,7 @@ class DeleteRelationshipServiceSpec extends UnitSpec {
 
     def givenETMPDeAuthSucceeds =
       when(ifConnector.deleteAgentRelationship(eqs(mtdItId), eqs(arn))(any[HeaderCarrier], any[ExecutionContext]))
-        .thenReturn(Future.successful(RegistrationRelationshipResponse(LocalDate.now.toString)))
+        .thenReturn(Future.successful(Some(RegistrationRelationshipResponse(LocalDate.now.toString))))
 
     def givenETMPDeAuthFails =
       when(ifConnector.deleteAgentRelationship(eqs(mtdItId), eqs(arn))(any[HeaderCarrier], any[ExecutionContext]))


### PR DESCRIPTION
- 4xx/5xx errors received for _IFConnector//MappingConnector_ are intercepted, and **not** re-thrown to clients of ACR.
- Some methods returning _Future[Unit]_ have been updated to return _Future_ of some value so such values can be used to determine further processing of flow
- Checks have been added with for-comprehension guards in a few places