### PR TITLE
Apb 7684 [CS] bug fix: allow pillar2 relationships to be found

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/connectors/IFConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/connectors/IFConnector.scala
@@ -104,7 +104,7 @@ class IFConnector @Inject() (httpClient: HttpClient, metrics: Metrics, agentCach
         )
       case PlrId(_) =>
         new URL(
-          s"$ifBaseUrl/registration/relationship?idType=PLR&referenceNumber=$encodedClientId&agent=false&active-only=true&regime=${getRegimeFor(taxIdentifier)}"
+          s"$ifBaseUrl/registration/relationship?idType=ZPLR&referenceNumber=$encodedClientId&agent=false&active-only=true&regime=${getRegimeFor(taxIdentifier)}"
         )
       case _ => throw new IllegalStateException(s"Unsupported Identifier $taxIdentifier")
 
@@ -295,7 +295,7 @@ class IFConnector @Inject() (httpClient: HttpClient, metrics: Metrics, agentCach
         )
       case PlrId(_) =>
         new URL(
-          s"$ifBaseUrl/registration/relationship?idType=PLR&referenceNumber=$encodedClientId&agent=false&active-only=false&regime=${getRegimeFor(taxIdentifier)}&from=$from&to=$now"
+          s"$ifBaseUrl/registration/relationship?idType=ZPLR&referenceNumber=$encodedClientId&agent=false&active-only=false&regime=${getRegimeFor(taxIdentifier)}&from=$from&to=$now"
         )
       case _ => throw new IllegalStateException(s"Unsupported Identifier $taxIdentifier")
 

--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sbt clean compile coverage test it:test coverageReport

--- a/export-versions-for-it-tests
+++ b/export-versions-for-it-tests
@@ -1,1 +1,0 @@
-export DATASTREAM_VERSION=3.11.0

--- a/it/uk/gov/hmrc/agentclientrelationships/stubs/IFStubs.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/stubs/IFStubs.scala
@@ -25,7 +25,7 @@ trait IFStubs {
     case CbcId(ref) =>
       s"/registration/relationship?idType=CBC&referenceNumber=$ref&agent=false&active-only=true&regime=CBC"
     case PlrId(ref) =>
-      s"/registration/relationship?idType=PLR&referenceNumber=$ref&agent=false&active-only=true&regime=PLR"
+      s"/registration/relationship?idType=ZPLR&referenceNumber=$ref&agent=false&active-only=true&regime=PLR"
     case x => throw new IllegalArgumentException(s"Tax identifier not supported $x")
   }
 
@@ -381,7 +381,7 @@ trait IFStubs {
     case PptRef(ref) =>
       s"/registration/relationship?idType=ZPPT&referenceNumber=$ref&agent=false&active-only=false&regime=PPT&from=2015-01-01&to=${LocalDate.now().toString}&relationship=ZA01&auth-profile=ALL00001"
     case PlrId(ref) =>
-      s"/registration/relationship?idType=PLR&referenceNumber=$ref&agent=false&active-only=false&regime=PLR&from=2015-01-01&to=${LocalDate.now().toString}"
+      s"/registration/relationship?idType=ZPLR&referenceNumber=$ref&agent=false&active-only=false&regime=PLR&from=2015-01-01&to=${LocalDate.now().toString}"
     case x => throw new IllegalArgumentException(s"Tax identifier not supported $x")
   }
 

--- a/it/uk/gov/hmrc/agentclientrelationships/stubs/IFStubs.scala
+++ b/it/uk/gov/hmrc/agentclientrelationships/stubs/IFStubs.scala
@@ -29,7 +29,7 @@ trait IFStubs {
     case x => throw new IllegalArgumentException(s"Tax identifier not supported $x")
   }
 
-  def givenNinoIsKnownFor(mtdId: MtdItId, nino: Nino) =
+  def givenNinoIsKnownFor(mtdId: MtdItId, nino: Nino): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/mtdId/${mtdId.value}"))
         .willReturn(
@@ -39,19 +39,19 @@ trait IFStubs {
         )
     )
 
-  def givenNinoIsUnknownFor(mtdId: MtdItId) =
+  def givenNinoIsUnknownFor(mtdId: MtdItId): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/mtdId/${mtdId.value}"))
         .willReturn(aResponse().withStatus(404))
     )
 
-  def givenmtdIdIsInvalid(mtdId: MtdItId) =
+  def givenmtdIdIsInvalid(mtdId: MtdItId): StubMapping =
     stubFor(
       get(urlMatching(s"/registration/.*?/mtdId/${mtdId.value}"))
         .willReturn(aResponse().withStatus(400))
     )
 
-  def givenMtdItIdIsKnownFor(nino: Nino, mtdId: MtdItId) =
+  def givenMtdItIdIsKnownFor(nino: Nino, mtdId: MtdItId): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
         .willReturn(
@@ -61,31 +61,31 @@ trait IFStubs {
         )
     )
 
-  def givenMtdItIdIsUnKnownFor(nino: Nino) =
+  def givenMtdItIdIsUnKnownFor(nino: Nino): StubMapping =
     stubFor(
       get(urlEqualTo(s"/registration/business-details/nino/${nino.value}"))
         .willReturn(aResponse().withStatus(404))
     )
 
-  def givenNinoIsInvalid(nino: Nino) =
+  def givenNinoIsInvalid(nino: Nino): StubMapping =
     stubFor(
       get(urlMatching(s"/registration/.*?/nino/${nino.value}"))
         .willReturn(aResponse().withStatus(400))
     )
 
-  def givenIFReturnsServerError() =
+  def givenIFReturnsServerError(): StubMapping =
     stubFor(
       any(urlMatching(s"/registration/.*"))
         .willReturn(aResponse().withStatus(500))
     )
 
-  def givenIFReturnsServiceUnavailable() =
+  def givenIFReturnsServiceUnavailable(): StubMapping =
     stubFor(
       any(urlMatching(s"/registration/.*"))
         .willReturn(aResponse().withStatus(503))
     )
 
-  def givenAgentCanBeAllocatedInIF(taxIdentifier: TaxIdentifier, arn: Arn) =
+  def givenAgentCanBeAllocatedInIF(taxIdentifier: TaxIdentifier, arn: Arn): StubMapping =
     stubFor(
       post(urlEqualTo(s"/registration/relationship"))
         .withRequestBody(containing(taxIdentifier.value))
@@ -98,7 +98,7 @@ trait IFStubs {
         )
     )
 
-  def givenAgentCanNotBeAllocatedInIF(status: Int) =
+  def givenAgentCanNotBeAllocatedInIF(status: Int): StubMapping =
     stubFor(
       post(urlEqualTo(s"/registration/relationship"))
         .withRequestBody(containing("\"Authorise\""))
@@ -109,7 +109,7 @@ trait IFStubs {
         )
     )
 
-  def givenAgentCanBeDeallocatedInIF(taxIdentifier: TaxIdentifier, arn: Arn) =
+  def givenAgentCanBeDeallocatedInIF(taxIdentifier: TaxIdentifier, arn: Arn): StubMapping =
     stubFor(
       post(urlEqualTo(s"/registration/relationship"))
         .withRequestBody(containing(taxIdentifier.value))
@@ -122,7 +122,7 @@ trait IFStubs {
         )
     )
 
-  def givenAgentHasNoActiveRelationshipInIF(taxIdentifier: TaxIdentifier, arn: Arn) =
+  def givenAgentHasNoActiveRelationshipInIF(taxIdentifier: TaxIdentifier, arn: Arn): StubMapping =
     stubFor(
       post(urlEqualTo(s"/registration/relationship"))
         .withRequestBody(containing(taxIdentifier.value))
@@ -135,7 +135,7 @@ trait IFStubs {
         )
     )
 
-  def givenAgentCanNotBeDeallocatedInIF(status: Int) =
+  def givenAgentCanNotBeDeallocatedInIF(status: Int): StubMapping =
     stubFor(
       post(urlEqualTo(s"/registration/relationship"))
         .withRequestBody(containing("\"De-Authorise\""))
@@ -165,7 +165,7 @@ trait IFStubs {
         )
     )
 
-  def getActiveRelationshipsViaClient(taxIdentifier: TaxIdentifier, arn: Arn) =
+  def getActiveRelationshipsViaClient(taxIdentifier: TaxIdentifier, arn: Arn): StubMapping =
     stubFor(
       get(urlEqualTo(url(taxIdentifier)))
         .willReturn(
@@ -458,7 +458,11 @@ trait IFStubs {
         )
     )
 
-  def getFailInactiveRelationshipsForClient(taxIdentifier: TaxIdentifier, status: Int, body: Option[String] = None) =
+  def getFailInactiveRelationshipsForClient(
+    taxIdentifier: TaxIdentifier,
+    status: Int,
+    body: Option[String] = None
+  ): StubMapping =
     stubFor(
       get(urlEqualTo(inactiveUrlClient(taxIdentifier)))
         .willReturn(aResponse().withStatus(status).withBody(body.getOrElse("")))
@@ -532,7 +536,7 @@ trait IFStubs {
         )
     )
 
-  def getFailAgentInactiveRelationships(encodedArn: String, status: Int) =
+  def getFailAgentInactiveRelationships(encodedArn: String, status: Int): StubMapping =
     stubFor(
       get(urlEqualTo(inactiveUrl(Arn(encodedArn))))
         .willReturn(
@@ -541,7 +545,7 @@ trait IFStubs {
         )
     )
 
-  def getFailWithSuspendedAgentInactiveRelationships(encodedArn: String) =
+  def getFailWithSuspendedAgentInactiveRelationships(encodedArn: String): StubMapping =
     stubFor(
       get(urlEqualTo(inactiveUrl(Arn(encodedArn))))
         .willReturn(
@@ -551,7 +555,7 @@ trait IFStubs {
         )
     )
 
-  def getFailWithInvalidAgentInactiveRelationships(encodedArn: String) =
+  def getFailWithInvalidAgentInactiveRelationships(encodedArn: String): StubMapping =
     stubFor(
       get(urlEqualTo(inactiveUrl(Arn(encodedArn))))
         .willReturn(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.17.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sbt run


### PR DESCRIPTION
The bug was around active relationships but the inactive relationships URL was affected as well.
They both use IF API#1168 and still looking into a neater way to handle the URLs compared to what's there atm - but don't want to hold up the fix while I do that. Tested locally:

MYTA - can see relationship and start client de-auth
<img width="1041" alt="Screenshot 2024-01-25 at 14 05 22" src="https://github.com/hmrc/agent-client-relationships/assets/62263396/34f88c0e-a320-4b9b-9fe4-3fe0acf828ed">
Helpdesk, deauth
<img width="1014" alt="Screenshot 2024-01-25 at 14 08 20" src="https://github.com/hmrc/agent-client-relationships/assets/62263396/e153c5fa-4ca8-4e4e-bdc7-3f864fd54172">

History
<img width="1043" alt="Screenshot 2024-01-25 at 14 03 06" src="https://github.com/hmrc/agent-client-relationships/assets/62263396/aa00fe82-330b-4f8a-a487-896ede48640d">
<img width="1019" alt="Screenshot 2024-01-25 at 14 05 35" src="https://github.com/hmrc/agent-client-relationships/assets/62263396/00c9c904-2077-446c-858b-88db0fdf7c75">
