### PR TITLE
Apb 8682

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/connectors/AgentClientAuthorisationConnector.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/connectors/AgentClientAuthorisationConnector.scala
@@ -72,14 +72,17 @@ class AgentClientAuthorisationConnector @Inject() (httpClient: HttpClient)(impli
     }
   }
 
-  def updateAltItsaFor(nino: Nino)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
+  def updateAltItsaFor(nino: Nino, service: String)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[Boolean] = {
 
     val url: URL = new URL(
       acaBaseUrl,
-      s"/agent-client-authorisation/alt-itsa/update/${encodePathSegment(nino.value)}"
+      s"/agent-client-authorisation/alt-itsa/$service/update/nino/${encodePathSegment(nino.value)}"
     )
 
-    monitor(s"ConsumedAPI-ACA-updateAltItsaFor-PUT") {
+    monitor(s"ConsumedAPI-ACA-updateAltItsaFor$service-PUT") {
       httpClient
         .PUTString[HttpResponse](url = url.toString, "")
         .map { response =>

--- a/app/uk/gov/hmrc/agentclientrelationships/services/CheckAndCopyRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/CheckAndCopyRelationshipsService.scala
@@ -290,7 +290,7 @@ class CheckAndCopyRelationshipsService @Inject() (
   )(implicit ec: ExecutionContext, hc: HeaderCarrier, request: Request[Any], auditData: AuditData): Future[Boolean] =
     lookupCesaForOldRelationship(arn, nino).flatMap(matching =>
       if (matching.isEmpty) {
-        aca.getPartialAuthExistsFor(nino, arn, Service.MtdIt.id).map { hasPartialAuth =>
+        aca.getPartialAuthExistsFor(nino, arn).map { hasPartialAuth =>
           auditData.set("partialAuth", hasPartialAuth)
           auditService.sendCheckCESAAuditEvent
           hasPartialAuth

--- a/it/test/uk/gov/hmrc/agentclientrelationships/connectors/AgentClientAuthorisationConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/connectors/AgentClientAuthorisationConnectorSpec.scala
@@ -94,4 +94,15 @@ class AgentClientAuthorisationConnectorSpec(implicit ec: ExecutionContext)
       timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-GET")
     }
   }
+
+  "updateAltItsaFor" should {
+    "return true when response is 201" in {
+      givenAltItsaUpdate(nino, responseStatus = 201)
+      givenCleanMetricRegistry()
+      val result = await(acaConnector.updateAltItsaFor(nino, HMRCMTDIT))
+      result shouldBe true
+      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-updateAltItsaForHMRC-MTD-IT-PUT")
+
+    }
+  }
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationships/connectors/AgentClientAuthorisationConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/connectors/AgentClientAuthorisationConnectorSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.agentclientrelationships.stubs.ACAStubs
 import uk.gov.hmrc.agentclientrelationships.support.{MetricTestSupport, WireMockSupport}
 import uk.gov.hmrc.agentclientrelationships.support.UnitSpec
+import uk.gov.hmrc.agentmtdidentifiers.model.Service.{HMRCMTDIT, HMRCMTDITSUPP}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient}
 
@@ -61,30 +62,36 @@ class AgentClientAuthorisationConnectorSpec(implicit ec: ExecutionContext)
 
   "getPartialAuthExistsFor" should {
 
-    "return true when a record exists with status PartialAuth for client" in {
-      givenPartialAuthExistsFor(agentARN, nino)
+    "return true when a record exists with status PartialAuth for main agent type" in {
+      givenPartialAuthExistsFor(agentARN, nino, HMRCMTDIT)
       givenCleanMetricRegistry()
-      val result = await(acaConnector.getPartialAuthExistsFor(nino, agentARN, "HMRC-MTD-IT"))
+      val result = await(acaConnector.getPartialAuthExistsFor(nino, agentARN))
       result shouldBe true
-      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-HMRC-MTD-IT-GET")
+      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-GET")
+    }
+
+    "return true when a record exists with status PartialAuth for supporting agent type" in {
+      givenPartialAuthExistsFor(agentARN, nino, HMRCMTDITSUPP)
+      givenCleanMetricRegistry()
+      val result = await(acaConnector.getPartialAuthExistsFor(nino, agentARN))
+      result shouldBe true
+      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-GET")
     }
 
     "return false when no record exists with PartialAuth for client" in {
       givenPartialAuthNotExistsFor(agentARN, nino)
       givenCleanMetricRegistry()
-      val result = await(acaConnector.getPartialAuthExistsFor(nino, agentARN, "HMRC-MTD-IT"))
+      val result = await(acaConnector.getPartialAuthExistsFor(nino, agentARN))
       result shouldBe false
-      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-HMRC-MTD-IT-GET")
+      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-GET")
     }
 
     "return false when there is a problem with the upstream service" in {
       givenAgentClientAuthorisationReturnsError(agentARN, nino, 503)
       givenCleanMetricRegistry()
-      val result = await(acaConnector.getPartialAuthExistsFor(nino, agentARN, "HMRC-MTD-IT"))
+      val result = await(acaConnector.getPartialAuthExistsFor(nino, agentARN))
       result shouldBe false
-      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-HMRC-MTD-IT-GET")
+      timerShouldExistsAndBeenUpdated("ConsumedAPI-ACA-getPartialAuthExistsFor-GET")
     }
-
   }
-
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsBaseControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsBaseControllerISpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.agentclientrelationships.controllers
 import com.google.inject.AbstractModule
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.Application
@@ -51,7 +52,8 @@ trait RelationshipsBaseControllerISpec
     with MockitoSugar
     with JsonMatchers
     with ACAStubs
-    with AUCDStubs {
+    with AUCDStubs
+    with IntegrationPatience {
 
   lazy val mockAuthConnector: AuthConnector = mock[PlayAuthConnector]
   override implicit lazy val app: Application = appBuilder
@@ -120,6 +122,7 @@ trait RelationshipsBaseControllerISpec
   val arn3 = Arn("AARN0000006")
   val mtdItId = MtdItId("ABCDEF123456789")
   val mtdItEnrolmentKey: EnrolmentKey = EnrolmentKey(Service.MtdIt, mtdItId)
+  val mtdItSuppEnrolmentKey: EnrolmentKey = EnrolmentKey(Service.MtdItSupp, mtdItId)
   val mtdItIdUriEncoded: String = UriEncoding.encodePathSegment(mtdItId.value, "UTF-8")
   val vrn = Vrn("101747641")
   val vatEnrolmentKey: EnrolmentKey = EnrolmentKey(Service.Vat, vrn)

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSABehaviours.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSABehaviours.scala
@@ -70,7 +70,7 @@ trait RelationshipsControllerITSABehaviours { this: RelationshipsBaseControllerI
         givenNinoIsKnownFor(mtdItId, nino)
         givenClientHasNoActiveRelationshipWithAgentInCESA(nino)
         givenAdminUser("foo", "any")
-        givenAltItsaUpdate(nino, 200)
+        givenAltItsaUpdate(nino, responseStatus = 200)
         givenUserIsSubscribedAgent(arn, withThisGroupId = "foo", withThisGgUserId = "any", withThisAgentCode = "bar")
 
         val result = doRequest
@@ -86,7 +86,7 @@ trait RelationshipsControllerITSABehaviours { this: RelationshipsBaseControllerI
         givenClientHasRelationshipWithAgentInCESA(nino, "foo")
         givenArnIsUnknownFor(arn)
         givenAdminUser("foo", "any")
-        givenAltItsaUpdate(nino, 200)
+        givenAltItsaUpdate(nino, responseStatus = 200)
         givenUserIsSubscribedAgent(arn, withThisGroupId = "foo", withThisGgUserId = "any", withThisAgentCode = "bar")
 
         val result = doRequest
@@ -131,7 +131,7 @@ trait RelationshipsControllerITSABehaviours { this: RelationshipsBaseControllerI
             "agentCode"               -> "bar",
             "nino"                    -> nino.value,
             "saAgentRef"              -> "foo",
-            "service"                 -> "mtd-it",
+            "service"                 -> "HMRC-MTD-IT",
             "clientId"                -> mtdItId.value,
             "clientIdType"            -> "mtditid",
             "CESARelationship"        -> "true",
@@ -168,7 +168,7 @@ trait RelationshipsControllerITSABehaviours { this: RelationshipsBaseControllerI
         givenArnIsUnknownFor(arn)
         givenClientHasNoRelationshipWithAnyAgentInCESA(nino)
         givenAdminUser("foo", "any")
-        givenAltItsaUpdate(nino, 201)
+        givenAltItsaUpdate(nino, responseStatus = 201)
         givenUserIsSubscribedAgent(arn, withThisGroupId = "foo", withThisGgUserId = "any", withThisAgentCode = "bar")
 
         val result = doRequest
@@ -185,7 +185,7 @@ trait RelationshipsControllerITSABehaviours { this: RelationshipsBaseControllerI
         givenArnIsUnknownFor(arn)
         givenClientHasNoRelationshipWithAnyAgentInCESA(nino)
         givenAdminUser("foo", "any")
-        givenAltItsaUpdate(nino, 200)
+        givenAltItsaUpdate(nino, responseStatus = 200)
         givenUserIsSubscribedAgent(arn, withThisGroupId = "foo", withThisGgUserId = "any", withThisAgentCode = "bar")
 
         val result = doRequest
@@ -257,7 +257,7 @@ trait RelationshipsControllerITSABehaviours { this: RelationshipsBaseControllerI
             "agentCode"               -> "bar",
             "nino"                    -> nino.value,
             "saAgentRef"              -> "foo",
-            "service"                 -> "mtd-it",
+            "service"                 -> "HMRC-MTD-IT",
             "clientId"                -> mtdItId.value,
             "clientIdType"            -> "mtditid",
             "CESARelationship"        -> "true",

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSASUPP.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSASUPP.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.controllers
+
+import uk.gov.hmrc.agentclientrelationships.audit.AgentClientRelationshipEvent
+
+trait RelationshipsControllerITSASUPP {
+  this: RelationshipsBaseControllerISpec =>
+
+  def relationshipControllerITSASUPPBehaviours(): Unit = {
+    val requestPath: String =
+      s"/agent-client-relationships/agent/${arn.value}/service/HMRC-MTD-IT-SUPP/client/MTDITID/${mtdItId.value}"
+
+    def doRequest = doAgentGetRequest(requestPath)
+
+    "GET /agent/:arn/service/HMRC-MTD-IT-SUPP/client/MTDITID/:mtdItId" should {
+
+      "return 404 when agent not allocated to client in es nor identifier not found in des" in {
+        givenPrincipalAgentUser(arn, "foo")
+        givenGroupInfo("foo", "bar")
+        givenDelegatedGroupIdsNotExistFor(mtdItSuppEnrolmentKey)
+        givenNinoIsUnknownFor(mtdItId)
+        givenAdminUser("foo", "any")
+        givenUserIsSubscribedAgent(arn, withThisGroupId = "foo", withThisGgUserId = "any", withThisAgentCode = "bar")
+
+        val result = doRequest
+        result.status shouldBe 404
+        (result.json \ "code").as[String] shouldBe "RELATIONSHIP_NOT_FOUND"
+      }
+
+      "return 404 when agent not allocated to client in es and no alt-itsa" in {
+        givenPrincipalAgentUser(arn, "foo")
+        givenGroupInfo("foo", "bar")
+        givenDelegatedGroupIdsNotExistFor(mtdItSuppEnrolmentKey)
+        givenNinoIsKnownFor(mtdItId, nino)
+        givenAdminUser("foo", "any")
+        givenAltItsaUpdate(nino, responseStatus = 404)
+        givenUserIsSubscribedAgent(arn, withThisGroupId = "foo", withThisGgUserId = "any", withThisAgentCode = "bar")
+
+        val result = doRequest
+        result.status shouldBe 404
+        (result.json \ "code").as[String] shouldBe "RELATIONSHIP_NOT_FOUND"
+      }
+
+      "return 200 when agent not allocated to client in es but partial auth exists" in {
+        givenPrincipalAgentUser(arn, "foo")
+        givenGroupInfo("foo", "bar")
+        givenDelegatedGroupIdsNotExistFor(mtdItSuppEnrolmentKey)
+        givenNinoIsKnownFor(mtdItId, nino)
+        givenMtdItIdIsKnownFor(nino, mtdItId)
+        givenAgentCanBeAllocatedInIF(mtdItId, arn)
+        givenMTDITSUPPEnrolmentAllocationSucceeds(mtdItId, "bar")
+        givenAdminUser("foo", "any")
+        givenUserIsSubscribedAgent(arn, withThisGroupId = "foo", withThisGgUserId = "any", withThisAgentCode = "bar")
+
+        val result = doRequest
+        result.status shouldBe 200
+
+        verifyAuditRequestSent(
+          1,
+          event = AgentClientRelationshipEvent.CreateRelationship,
+          detail = Map(
+            "arn"                     -> arn.value,
+            "credId"                  -> "any",
+            "agentCode"               -> "bar",
+            "nino"                    -> nino.value,
+            "saAgentRef"              -> "foo",
+            "service"                 -> "HMRC-MTD-IT-SUPP",
+            "clientId"                -> mtdItId.value,
+            "clientIdType"            -> "mtditid",
+            "etmpRelationshipCreated" -> "true",
+            "enrolmentDelegated"      -> "true",
+            "AgentDBRecord"           -> "true",
+            "Journey"                 -> "Alt ITSA"
+          ),
+          tags = Map("transactionName" -> "create-relationship", "path" -> requestPath)
+        )
+      }
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerWithoutMongoISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerWithoutMongoISpec.scala
@@ -140,7 +140,7 @@ class RelationshipsControllerWithoutMongoISpec
           "arn"                     -> arn.value,
           "nino"                    -> nino.value,
           "saAgentRef"              -> "foo",
-          "service"                 -> "mtd-it",
+          "service"                 -> "HMRC-MTD-IT",
           "clientId"                -> mtditid.value,
           "clientIdType"            -> "mtditid",
           "CESARelationship"        -> "true",

--- a/it/test/uk/gov/hmrc/agentclientrelationships/repository/DeleteRecordRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/repository/DeleteRecordRepositoryISpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentclientrelationships.repository
 
 import org.mongodb.scala.MongoException
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -29,7 +30,7 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId, Service, Vrn}
 import java.time.temporal.ChronoUnit.MILLIS
 import java.time.{Instant, LocalDateTime, ZoneOffset}
 
-class DeleteRecordRepositoryISpec extends UnitSpec with MongoApp with GuiceOneAppPerSuite {
+class DeleteRecordRepositoryISpec extends UnitSpec with MongoApp with GuiceOneAppPerSuite with IntegrationPatience {
 
   protected def appBuilder: GuiceApplicationBuilder =
     new GuiceApplicationBuilder()

--- a/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ACAStubs.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ACAStubs.scala
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.agentclientrelationships.support.WireMockSupport
+import uk.gov.hmrc.agentmtdidentifiers.model.Service.HMRCMTDIT
 import uk.gov.hmrc.domain.{Nino, TaxIdentifier}
 
 trait ACAStubs {
@@ -119,9 +120,9 @@ trait ACAStubs {
         )
     )
 
-  def givenAltItsaUpdate(nino: Nino, responseStatus: Int) =
+  def givenAltItsaUpdate(nino: Nino, service: String = HMRCMTDIT, responseStatus: Int) =
     stubFor(
-      put(urlEqualTo(s"/agent-client-authorisation/alt-itsa/update/${nino.value}"))
+      put(urlEqualTo(s"/agent-client-authorisation/alt-itsa/$service/update/nino/${nino.value}"))
         .willReturn(aResponse().withStatus(responseStatus))
     )
 

--- a/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ACAStubs.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ACAStubs.scala
@@ -25,11 +25,11 @@ import uk.gov.hmrc.domain.{Nino, TaxIdentifier}
 trait ACAStubs {
   me: WireMockSupport =>
 
-  def givenPartialAuthExistsFor(arn: Arn, nino: Nino) =
+  def givenPartialAuthExistsFor(arn: Arn, nino: Nino, service: String) =
     stubFor(
       get(
         urlEqualTo(
-          s"/agent-client-authorisation/agencies/${arn.value}/invitations/sent?status=PartialAuth&clientId=${nino.value}&service=HMRC-MTD-IT"
+          s"/agent-client-authorisation/agencies/${arn.value}/invitations/sent?status=PartialAuth&clientId=${nino.value}"
         )
       )
         .willReturn(
@@ -41,7 +41,7 @@ trait ACAStubs {
                          |            "href": "/agent-client-authorisation/agencies/${arn.value}/invitations/sent/AX6U1MAPY88GR"
                          |        },
                          |        "self": {
-                         |            "href": "/agent-client-authorisation/agencies/${arn.value}/invitations/sent?service=HMRC-MTD-IT&clientId=${nino.value}&status=PartialAuth"
+                         |            "href": "/agent-client-authorisation/agencies/${arn.value}/invitations/sent?clientId=${nino.value}&status=PartialAuth"
                          |        }
                          |    },
                          |    "_embedded": {
@@ -67,7 +67,7 @@ trait ACAStubs {
                          |                "expiryDate": "2021-05-19",
                          |                "lastUpdated": "2021-04-28T18:08:51.786+01:00",
                          |                "clientType": "personal",
-                         |                "service": "HMRC-MTD-IT",
+                         |                "service": "$service",
                          |                "suppliedClientId": "AB213308A",
                          |                "relationshipEndedBy": null,
                          |                "clientIdType": "MTDITID",
@@ -84,7 +84,7 @@ trait ACAStubs {
     stubFor(
       get(
         urlEqualTo(
-          s"/agent-client-authorisation/agencies/${arn.value}/invitations/sent?status=PartialAuth&clientId=${nino.value}&service=HMRC-MTD-IT"
+          s"/agent-client-authorisation/agencies/${arn.value}/invitations/sent?status=PartialAuth&clientId=${nino.value}"
         )
       )
         .willReturn(
@@ -96,7 +96,7 @@ trait ACAStubs {
                          |            "href": "/agent-client-authorisation/agencies/YARN8313176/invitations/sent/AX6U1MAPY88GR"
                          |        },
                          |        "self": {
-                         |            "href": "/agent-client-authorisation/agencies/YARN8313176/invitations/sent?service=HMRC-MTD-IT&clientId=AB213308A&status=PartialAuth"
+                         |            "href": "/agent-client-authorisation/agencies/YARN8313176/invitations/sent?clientId=AB213308A&status=PartialAuth"
                          |        }
                          |    },
                          |    "_embedded": {
@@ -110,7 +110,7 @@ trait ACAStubs {
     stubFor(
       get(
         urlEqualTo(
-          s"/agent-client-authorisation/agencies/${arn.value}/invitations/sent?status=PartialAuth&clientId=${nino.value}&service=HMRC-MTD-IT"
+          s"/agent-client-authorisation/agencies/${arn.value}/invitations/sent?status=PartialAuth&clientId=${nino.value}"
         )
       )
         .willReturn(

--- a/it/test/uk/gov/hmrc/agentclientrelationships/stubs/RelationshipStubs.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/stubs/RelationshipStubs.scala
@@ -30,6 +30,9 @@ trait RelationshipStubs extends EnrolmentStoreProxyStubs with UsersGroupsSearchS
   def givenDelegatedGroupIdsNotExistForMtdItId(mtdItId: MtdItId) =
     givenDelegatedGroupIdsNotExistFor(EnrolmentKey(Service.MtdIt, mtdItId))
 
+  def givenDelegatedGroupIdsNotExistForMtdItIdSupp(mtdItId: MtdItId) =
+    givenDelegatedGroupIdsNotExistFor(EnrolmentKey(Service.MtdItSupp, mtdItId))
+
   def givenDelegatedGroupIdsExistForMtdItId(mtdItId: MtdItId, ids: String*) =
     givenDelegatedGroupIdsExistFor(EnrolmentKey(Service.MtdIt, mtdItId), Set("bar", "foo") ++ ids.toSet)
 
@@ -44,6 +47,9 @@ trait RelationshipStubs extends EnrolmentStoreProxyStubs with UsersGroupsSearchS
 
   def givenMTDITEnrolmentAllocationSucceeds(mtdItId: MtdItId, agentCode: String) =
     givenEnrolmentAllocationSucceeds("foo", "any", EnrolmentKey(Service.MtdIt, mtdItId), agentCode)
+
+  def givenMTDITSUPPEnrolmentAllocationSucceeds(mtdItId: MtdItId, agentCode: String) =
+    givenEnrolmentAllocationSucceeds("foo", "any", EnrolmentKey(Service.MtdItSupp, mtdItId), agentCode)
 
   def givenMTDVATEnrolmentAllocationSucceeds(vrn: Vrn, agentCode: String) =
     givenEnrolmentAllocationSucceeds("foo", "any", EnrolmentKey(Service.Vat, vrn), agentCode)

--- a/it/test/uk/gov/hmrc/agentclientrelationships/support/RecoverySchedulerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/support/RecoverySchedulerISpec.scala
@@ -35,7 +35,6 @@ import uk.gov.hmrc.mongo.test.MongoSupport
 
 import java.time.{LocalDateTime, ZoneOffset}
 import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
 
 class RecoverySchedulerISpec(implicit val ec: ExecutionContext)

--- a/test/uk/gov/hmrc/agentclientrelationships/services/CheckAndCopyRelationshipServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/services/CheckAndCopyRelationshipServiceSpec.scala
@@ -40,6 +40,7 @@ import uk.gov.hmrc.domain._
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.agentclientrelationships.support.UnitSpec
+import uk.gov.hmrc.agentmtdidentifiers.model.Service.{HMRCMTDIT, HMRCMTDITSUPP}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
@@ -51,6 +52,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
   val saAgentRef: SaAgentReference = SaAgentReference("T1113T")
   val mtdItId: MtdItId = MtdItId("ABCDEF123456789")
   val mtdItEnrolmentKey: EnrolmentKey = EnrolmentKey("HMRC-MTD-IT~MTDITID~ABCDEF123456789")
+  val mtdItSuppEnrolmentKey: EnrolmentKey = EnrolmentKey("HMRC-MTD-IT-SUPP~MTDITID~ABCDEF123456789")
   val vrn: Vrn = Vrn("101747641")
   val vatEnrolmentKey: EnrolmentKey = EnrolmentKey(Service.Vat, vrn)
   val agentUserId = "testUserId"
@@ -142,7 +144,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
         metricsStub()
 
         val check = relationshipsService
-          .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+          .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
 
         await(check) shouldBe FoundAndCopied
 
@@ -190,7 +192,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
           val maybeCheck: Option[CheckAndCopyResult] = await(lockService.tryLock(arn, mtdItEnrolmentKey) {
             relationshipsService
-              .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+              .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
           })
 
           maybeCheck.value shouldBe FoundButLockedCouldNotCopy
@@ -237,7 +239,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           tryCreateRelationshipFromAltItsa()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
           await(check) shouldBe AltItsaNotFoundOrFailed
 
           verifyEtmpRecordNotCreated()
@@ -294,7 +296,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           metricsStub()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
 
           await(check) shouldBe FoundAndCopied
 
@@ -343,7 +345,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
           val maybeCheck = await(lockService.tryLock(arn, mtdItEnrolmentKey) {
             relationshipsService
-              .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+              .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
           })
 
           maybeCheck.value shouldBe FoundButLockedCouldNotCopy
@@ -391,7 +393,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           tryCreateRelationshipFromAltItsa()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
           await(check) shouldBe AltItsaNotFoundOrFailed
 
           verifyEsRecordNotCreated()
@@ -438,7 +440,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           auditStub()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
 
           await(check) shouldBe FoundAndCopied
 
@@ -489,7 +491,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           tryCreateRelationshipFromAltItsa()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
           await(check) shouldBe AltItsaNotFoundOrFailed
 
           verifyEsRecordNotCreated()
@@ -526,7 +528,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
       mappingServiceUnavailable()
       val check = relationshipsService
-        .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+        .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
 
       an[UpstreamErrorResponse] should be thrownBy await(check)
       verifyEsRecordNotCreated()
@@ -567,7 +569,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
       relationshipWillBeCreated(mtdItEnrolmentKey)
 
       val check = relationshipsService
-        .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+        .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
 
       val checkAndCopyResult = await(check)
       checkAndCopyResult shouldBe AlreadyCopiedDidNotCheck
@@ -614,7 +616,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
         relationshipWillBeCreated(mtdItEnrolmentKey)
 
         val check = relationshipsService
-          .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+          .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
 
         val checkAndCopyResult = await(check)
         checkAndCopyResult shouldBe AlreadyCopiedDidNotCheck
@@ -658,7 +660,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
         val check = await(lockService.tryLock(arn, mtdItEnrolmentKey) {
           relationshipsService
-            .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
         })
 
         check.value shouldBe FoundButLockedCouldNotCopy
@@ -705,7 +707,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
         val check = await(lockService.tryLock(arn, vatEnrolmentKey) {
           relationshipsService
-            .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
         })
 
         check.value shouldBe FoundButLockedCouldNotCopy
@@ -746,12 +748,48 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
         val request = FakeRequest()
 
         cesaRelationshipDoesNotExist()
-        tryCreateRelationshipFromAltItsa(true)
+        tryCreateRelationshipFromAltItsa(created = true)
 
         val check = relationshipsService
-          .checkForOldRelationshipAndCopy(arn, mtdItId)(ec, hc, request, auditData)
+          .checkForOldRelationshipAndCopy(arn, mtdItEnrolmentKey)(ec, hc, request, auditData)
         await(check) shouldBe AltItsaCreateRelationshipSuccess
       }
+
+    "create relationship when there is an alt-itsa authorisation in place for supporting agent type. " in {
+      val relationshipCopyRepository = new FakeRelationshipCopyRecordRepository
+      val lockService = new FakeLockService
+      val relationshipsService = new CheckAndCopyRelationshipsService(
+        es,
+        ifConnector,
+        des,
+        mapping,
+        ugs,
+        aca,
+        relationshipCopyRepository,
+        new CreateRelationshipsService(
+          es,
+          ifConnector,
+          relationshipCopyRepository,
+          lockService,
+          deleteRecordRepository,
+          agentUserService,
+          aucdConnector,
+          metrics
+        ),
+        auditService,
+        metrics
+      )
+
+      val auditData = new AuditData()
+      val request = FakeRequest()
+
+      when(ifConnector.getNinoFor(eqs(mtdItId))(eqs(hc), eqs(ec))).thenReturn(Future successful Some(nino))
+      tryCreateRelationshipFromAltItsa(service = HMRCMTDITSUPP, created = true)
+
+      val check = relationshipsService
+        .checkForOldRelationshipAndCopy(arn, mtdItSuppEnrolmentKey)(ec, hc, request, auditData)
+      await(check) shouldBe AltItsaCreateRelationshipSuccess
+    }
   }
 
   "checkESForOldRelationshipAndCopyForMtdVat" should {
@@ -793,7 +831,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
         auditStub()
 
         val check = relationshipsService
-          .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+          .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
 
         await(check) shouldBe FoundAndCopied
 
@@ -844,7 +882,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
           val maybeCheck: Option[CheckAndCopyResult] = await(lockService.tryLock(arn, vatEnrolmentKey) {
             relationshipsService
-              .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+              .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
           })
 
           maybeCheck.value shouldBe FoundButLockedCouldNotCopy
@@ -891,7 +929,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           auditStub()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
           await(check) shouldBe NotFound
 
           verifyEtmpRecordNotCreatedForMtdVat()
@@ -931,7 +969,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
       auditStub()
 
       val check = relationshipsService
-        .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+        .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
       await(check) shouldBe VrnNotFoundInEtmp
 
       verifyEtmpRecordNotCreatedForMtdVat()
@@ -985,7 +1023,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           auditStub()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
 
           await(check) shouldBe FoundAndCopied
 
@@ -1036,7 +1074,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
 
           val maybeCheck = await(lockService.tryLock(arn, vatEnrolmentKey) {
             relationshipsService
-              .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+              .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
           })
 
           maybeCheck.value shouldBe FoundButLockedCouldNotCopy
@@ -1084,7 +1122,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           auditStub()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
           await(check) shouldBe NotFound
 
           verifyEsRecordNotCreated()
@@ -1132,7 +1170,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           relationshipWillBeCreated(vatEnrolmentKey)
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
 
           await(check) shouldBe FoundAndCopied
 
@@ -1183,7 +1221,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           auditStub()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
           await(check) shouldBe NotFound
 
           verifyEsRecordNotCreated()
@@ -1219,7 +1257,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
       val request = FakeRequest()
       mappingServiceUnavailableForMtdVat()
       val check = relationshipsService
-        .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+        .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
 
       an[UpstreamErrorResponse] should be thrownBy await(check)
 
@@ -1261,7 +1299,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
       relationshipWillBeCreated(vatEnrolmentKey)
 
       val check = relationshipsService
-        .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+        .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
 
       val checkAndCopyResult = await(check)
       checkAndCopyResult shouldBe AlreadyCopiedDidNotCheck
@@ -1308,7 +1346,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
         relationshipWillBeCreated(vatEnrolmentKey)
 
         val check = relationshipsService
-          .checkForOldRelationshipAndCopy(arn, vrn)(ec, hc, request, auditData)
+          .checkForOldRelationshipAndCopy(arn, vatEnrolmentKey)(ec, hc, request, auditData)
 
         val checkAndCopyResult = await(check)
         checkAndCopyResult shouldBe AlreadyCopiedDidNotCheck
@@ -1400,18 +1438,18 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
     when(servicesConfig.getString(any[String])).thenReturn("")
     var appConfig: AppConfig = new AppConfig(configuration, servicesConfig)
 
-    behave like copyHasBeenDisabled(mtdItId, appConfig)
+    behave like copyHasBeenDisabled(mtdItEnrolmentKey, appConfig)
 
     when(servicesConfig.getBoolean(eqs("features.copy-relationship.mtd-it"))).thenReturn(true)
     when(servicesConfig.getBoolean(eqs("features.copy-relationship.mtd-vat"))).thenReturn(false)
     when(servicesConfig.getString(any[String])).thenReturn("")
     appConfig = new AppConfig(configuration, servicesConfig)
 
-    behave like copyHasBeenDisabled(vrn, appConfig)
+    behave like copyHasBeenDisabled(vatEnrolmentKey, appConfig)
 
-    def copyHasBeenDisabled(identifier: TaxIdentifier, appConfig: AppConfig) =
-      s"not attempt to copy relationship for ${identifier.getClass.getSimpleName} " +
-        s"and return CopyRelationshipNotAllowed if feature flag is disabled (set to false)" in {
+    def copyHasBeenDisabled(enrolmentKey: EnrolmentKey, appConfig: AppConfig) =
+      s"not attempt to copy relationship for ${enrolmentKey.service} " +
+        s"and return CopyRelationshipNotEnabled if feature flag is disabled (set to false)" in {
           val relationshipCopyRepository = mock[RelationshipCopyRecordRepository]
           val lockService = mock[RecoveryLockService]
           val relationshipsService =
@@ -1441,7 +1479,7 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
           val request = FakeRequest()
 
           val check = relationshipsService
-            .checkForOldRelationshipAndCopy(arn, identifier)(ec, hc, request, auditData)
+            .checkForOldRelationshipAndCopy(arn, enrolmentKey)(ec, hc, request, auditData)
 
           await(check) shouldBe CopyRelationshipNotEnabled
 
@@ -1534,8 +1572,11 @@ class CheckAndCopyRelationshipServiceSpec extends UnitSpec with BeforeAndAfterEa
     ).thenReturn(Future successful (()))
   }
 
-  private def tryCreateRelationshipFromAltItsa(created: Boolean = false): OngoingStubbing[Future[Boolean]] =
-    when(aca.updateAltItsaFor(eqs(nino))(eqs(hc), eqs(ec))).thenReturn(Future successful created)
+  private def tryCreateRelationshipFromAltItsa(
+    service: String = HMRCMTDIT,
+    created: Boolean = false
+  ): OngoingStubbing[Future[Boolean]] =
+    when(aca.updateAltItsaFor(eqs(nino), eqs(service))(eqs(hc), eqs(ec))).thenReturn(Future successful created)
 
   private def metricsStub(): OngoingStubbing[MetricRegistry] =
     when(metrics.defaultRegistry).thenReturn(new MetricRegistry)


### PR DESCRIPTION
A supporting ITSA agent relationship can be created from an alt-ITSA invitation (with PartialAuth status). Unlike for a main agent relationship, this will not attempt to copy across a legacy SA relationship. 
Unlike for main agent, this solution does not look at the recovery record prior to resuming relationship creation. This is to simplify the solution for the Sandbox environment while we collect stats about the usefulness of the recovery system (additional logging has been added to help with this investigation). 