### PR TITLE
APB-8895 Update client details call to provide relationship information

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/ClientDetailsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/ClientDetailsController.scala
@@ -17,21 +17,25 @@
 package uk.gov.hmrc.agentclientrelationships.controllers
 
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import uk.gov.hmrc.agentclientrelationships.auth.AuthActions
 import uk.gov.hmrc.agentclientrelationships.config.AppConfig
 import uk.gov.hmrc.agentclientrelationships.model.clientDetails._
+import uk.gov.hmrc.agentclientrelationships.repository.InvitationsRepository
 import uk.gov.hmrc.agentclientrelationships.services.ClientDetailsService
 import uk.gov.hmrc.agentmtdidentifiers.model.Service
+import uk.gov.hmrc.agentmtdidentifiers.model.Service.{HMRCMTDIT, HMRCMTDITSUPP}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ClientDetailsController @Inject() (
   clientDetailsService: ClientDetailsService,
+  relationshipsController: RelationshipsController,
+  invitationsRepository: InvitationsRepository,
   val authConnector: AuthConnector,
   cc: ControllerComponents
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
@@ -40,14 +44,44 @@ class ClientDetailsController @Inject() (
 
   val supportedServices: Seq[Service] = appConfig.supportedServices
 
+  private def expectedResults(results: Seq[Result]): Boolean =
+    results.forall(result => result.header.status == 200 | result.header.status == 404)
+
+  private val multiAgentServices: Map[String, String] = Map(HMRCMTDIT -> HMRCMTDITSUPP)
+
   def findClientDetails(service: String, clientId: String): Action[AnyContent] = Action.async { implicit request =>
     withAuthorisedAsAgent { arn =>
       for {
         clientDetailsResponse <- clientDetailsService.findClientDetails(service, clientId)
+        clientIdType = Service(service).supportedSuppliedClientIdType.enrolmentId
+        pendingRelResponse <- invitationsRepository.findAllForAgent(arn.value)
+        existingRelResponseMain <-
+          relationshipsController.checkForRelationship(arn, service, clientIdType, clientId, None)(request)
+        existingRelResponseSupp <- if (multiAgentServices.contains(service))
+                                     relationshipsController.checkForRelationship(
+                                       arn,
+                                       multiAgentServices(service),
+                                       clientIdType,
+                                       clientId,
+                                       None
+                                     )(request)
+                                   else Future(NotFound)
       } yield clientDetailsResponse match {
-        case Right(details)              => Ok(Json.toJson(details))
+        case Right(details) if expectedResults(Seq(existingRelResponseMain, existingRelResponseSupp)) =>
+          val pendingRelationship = pendingRelResponse.exists(inv => inv.service == service && inv.clientId == clientId)
+          val existingRelationship =
+            (existingRelResponseMain.header.status, existingRelResponseSupp.header.status) match {
+              case (OK, _) => Some(service)
+              case (_, OK) => Some(multiAgentServices(service))
+              case _       => None
+            }
+          val response = details.copy(
+            hasPendingInvitation = pendingRelationship,
+            hasExistingRelationshipFor = existingRelationship
+          )
+          Ok(Json.toJson(response))
         case Left(ClientDetailsNotFound) => NotFound
-        case Left(_)                     => InternalServerError
+        case _                           => InternalServerError
       }
     }
   }

--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
@@ -91,10 +91,8 @@ class RelationshipsController @Inject() (
         withIrSaSuspensionCheck(arn) {
           checkLegacyWithNinoOrPartialAuth(arn, Nino(clientId))
         }
-      case (Service.MtdIt.id, "ni" | "NI", _) if Nino.isValid(clientId) =>
-        useMtdIdInEnrolmentKey(Service.MtdIt.id)
-      case (Service.MtdItSupp.id, "ni" | "NI", _) if Nino.isValid(clientId) =>
-        useMtdIdInEnrolmentKey(Service.MtdItSupp.id)
+      case (Service.MtdIt.id | Service.MtdItSupp.id, "ni" | "NI" | "NINO", _) if Nino.isValid(clientId) =>
+        useMtdIdInEnrolmentKey(service)
       case ("HMCE-VATDEC-ORG", "vrn", _) if Vrn.isValid(clientId) => checkWithVrn(arn, Vrn(clientId))
       // "normal" cases
       case (svc, idType, id) =>
@@ -244,10 +242,8 @@ class RelationshipsController @Inject() (
       // "special" cases
       case ("IR-SA", "ni" | "NI") if Nino.isValid(clientId) =>
         Future.successful(Right(EnrolmentKey("IR-SA", Nino(clientId))))
-      case (Service.MtdIt.id, "ni" | "NI") if Nino.isValid(clientId) =>
-        Future.successful(Right(EnrolmentKey(Service.MtdIt.id, Nino(clientId))))
-      case (Service.MtdItSupp.id, "ni" | "NI") if Nino.isValid(clientId) =>
-        Future.successful(Right(EnrolmentKey(Service.MtdItSupp.id, Nino(clientId))))
+      case (Service.MtdIt.id | Service.MtdItSupp.id, "ni" | "NI") if Nino.isValid(clientId) =>
+        Future.successful(Right(EnrolmentKey(serviceKey, Nino(clientId))))
       case ("HMCE-VATDEC-ORG", "vrn") if Vrn.isValid(clientId) =>
         Future.successful(Right(EnrolmentKey("HMCE-VATDEC-ORG", Vrn(clientId))))
       case (Service.Cbc.id, CbcIdType.enrolmentId) =>

--- a/app/uk/gov/hmrc/agentclientrelationships/model/clientDetails/ClientDetailsResponse.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/model/clientDetails/ClientDetailsResponse.scala
@@ -25,7 +25,9 @@ case class ClientDetailsResponse(
   status: Option[ClientStatus],
   isOverseas: Option[Boolean],
   knownFacts: Seq[String],
-  knownFactType: Option[KnownFactType]
+  knownFactType: Option[KnownFactType],
+  hasPendingInvitation: Boolean = false,
+  hasExistingRelationshipFor: Option[String] = None
 )
 
 object ClientDetailsResponse {

--- a/app/uk/gov/hmrc/agentclientrelationships/model/clientDetails/itsa/ItsaCitizenDetails.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/model/clientDetails/itsa/ItsaCitizenDetails.scala
@@ -21,7 +21,12 @@ import play.api.libs.json.{JsPath, Reads}
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-case class ItsaCitizenDetails(firstName: Option[String], lastName: Option[String], dateOfBirth: Option[LocalDate]) {
+case class ItsaCitizenDetails(
+  firstName: Option[String],
+  lastName: Option[String],
+  dateOfBirth: Option[LocalDate],
+  saUtr: Option[String]
+) {
   lazy val name: Option[String] = {
     val n = Seq(firstName, lastName).collect { case Some(x) => x }.mkString(" ")
     if (n.isEmpty) None else Some(n)
@@ -37,5 +42,6 @@ object ItsaCitizenDetails {
     lastName  <- (JsPath \ "name" \ "current" \ "lastName").readNullable[String]
     dateOfBirth <-
       (JsPath \ "dateOfBirth").readNullable[String].map(_.map(date => LocalDate.parse(date, citizenDateFormatter)))
-  } yield ItsaCitizenDetails(firstName, lastName, dateOfBirth)
+    saUtr <- (JsPath \ "ids" \ "sautr").readNullable[String]
+  } yield ItsaCitizenDetails(firstName, lastName, dateOfBirth, saUtr)
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationships/connectors/ClientDetailsConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/connectors/ClientDetailsConnectorISpec.scala
@@ -114,7 +114,7 @@ class ClientDetailsConnectorISpec
 
     "return business details when receiving a 200 status" in {
       givenAuditConnector()
-      givenItsaBusinessDetailsExists("AA000001B")
+      givenItsaBusinessDetailsExists("nino", "AA000001B")
       await(connector.getItsaBusinessDetails("AA000001B")) shouldBe Right(
         ItsaBusinessDetails("Erling Haal", Some("AA1 1AA"), "GB")
       )

--- a/it/test/uk/gov/hmrc/agentclientrelationships/connectors/ClientDetailsConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/connectors/ClientDetailsConnectorISpec.scala
@@ -91,7 +91,8 @@ class ClientDetailsConnectorISpec
     "return citizen details when receiving a 200 status" in {
       givenAuditConnector()
       givenItsaCitizenDetailsExists("AA000001B")
-      val expectedModel = ItsaCitizenDetails(Some("Matthew"), Some("Kovacic"), Some(LocalDate.parse("2000-01-01")))
+      val expectedModel =
+        ItsaCitizenDetails(Some("Matthew"), Some("Kovacic"), Some(LocalDate.parse("2000-01-01")), Some("11223344"))
       await(connector.getItsaCitizenDetails("AA000001B")) shouldBe Right(expectedModel)
     }
 

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/ClientDetailsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/ClientDetailsControllerISpec.scala
@@ -19,12 +19,17 @@ package uk.gov.hmrc.agentclientrelationships.controllers
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
-import play.api.test.Helpers.stubControllerComponents
+import play.api.test.Helpers.{await, defaultAwaitTimeout, stubControllerComponents}
 import uk.gov.hmrc.agentclientrelationships.config.AppConfig
+import uk.gov.hmrc.agentclientrelationships.model.EnrolmentKey
+import uk.gov.hmrc.agentclientrelationships.repository.InvitationsRepository
 import uk.gov.hmrc.agentclientrelationships.services.ClientDetailsService
 import uk.gov.hmrc.agentclientrelationships.stubs.ClientDetailsStub
+import uk.gov.hmrc.agentmtdidentifiers.model.Service.Vat
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId, Vrn}
 import uk.gov.hmrc.auth.core.AuthConnector
 
+import java.time.LocalDate
 import scala.concurrent.ExecutionContext
 
 class ClientDetailsControllerISpec extends RelationshipsBaseControllerISpec with ClientDetailsStub {
@@ -33,53 +38,210 @@ class ClientDetailsControllerISpec extends RelationshipsBaseControllerISpec with
   val authConnector: AuthConnector = app.injector.instanceOf[AuthConnector]
   implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
   implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  val repository: InvitationsRepository = app.injector.instanceOf[InvitationsRepository]
+  val relationshipsController: RelationshipsController = app.injector.instanceOf[RelationshipsController]
 
-  val controller = new ClientDetailsController(clientDetailsService, authConnector, stubControllerComponents())
+  val controller = new ClientDetailsController(
+    clientDetailsService,
+    relationshipsController,
+    repository,
+    authConnector,
+    stubControllerComponents()
+  )
 
   ".findClientDetails" should {
 
-    "return 200 status and valid JSON when API calls are successful and relevant checks have passed" in {
-      val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-IT/details/AA000001B")
-      givenAuthorisedAsValidAgent(request, "XARN1234567")
-      givenAuditConnector()
-      givenItsaBusinessDetailsExists("AA000001B")
+    "return 200 status and the expected JSON body" when {
 
-      val result = doAgentGetRequest(request.uri)
-      result.status shouldBe 200
-      result.json shouldBe Json.obj(
-        "name"          -> "Erling Haal",
-        "isOverseas"    -> false,
-        "knownFacts"    -> Json.arr("AA1 1AA"),
-        "knownFactType" -> "PostalCode"
-      )
+      "the client has no pending invitations or existing relationship with this agent & service" in {
+        val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
+        givenAuthorisedAsValidAgent(request, "XARN1234567")
+        givenAuditConnector()
+        givenVatCustomerInfoExists("101747641")
+        givenAgentGroupExistsFor("foo")
+        givenAdminUser("foo", "bar")
+        givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+        givenDelegatedGroupIdsNotExistFor(EnrolmentKey("HMRC-MTD-VAT", Vrn("101747641")))
+        givenDelegatedGroupIdsNotExistFor(EnrolmentKey("HMCE-VATDEC-ORG~VATRegNo~101747641"))
+
+        val result = doAgentGetRequest(request.uri)
+        result.status shouldBe 200
+        result.json shouldBe Json.obj(
+          "name"                 -> "CFG Solutions",
+          "knownFacts"           -> Json.arr("2020-01-01"),
+          "knownFactType"        -> "Date",
+          "hasPendingInvitation" -> false
+        )
+      }
+
+      "the client has a pending invitation" in {
+        val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
+        givenAuthorisedAsValidAgent(request, "XARN1234567")
+        givenAuditConnector()
+        givenVatCustomerInfoExists("101747641")
+        givenAgentGroupExistsFor("foo")
+        givenAdminUser("foo", "bar")
+        givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+        givenDelegatedGroupIdsNotExistFor(EnrolmentKey("HMRC-MTD-VAT", Vrn("101747641")))
+        givenDelegatedGroupIdsNotExistFor(EnrolmentKey("HMCE-VATDEC-ORG~VATRegNo~101747641"))
+        await(repository.create("XARN1234567", Vat, Vrn("101747641"), Vrn("101747641"), "My Name", LocalDate.now()))
+
+        val result = doAgentGetRequest(request.uri)
+        result.status shouldBe 200
+        result.json shouldBe Json.obj(
+          "name"                 -> "CFG Solutions",
+          "knownFacts"           -> Json.arr("2020-01-01"),
+          "knownFactType"        -> "Date",
+          "hasPendingInvitation" -> true
+        )
+      }
+
+      "the client has an existing relationship for this agent & service" when {
+
+        "the service supports multiple agents" when {
+
+          "the existing relationship is in a main role" in {
+            val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-IT/details/AA000001B")
+            givenAuthorisedAsValidAgent(request, "XARN1234567")
+            givenAuditConnector()
+            givenItsaBusinessDetailsExists("nino", "AA000001B")
+            givenItsaBusinessDetailsExists("mtdId", "XAIT0000111122")
+            givenAgentGroupExistsFor("foo")
+            givenAdminUser("foo", "bar")
+            givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+            givenDelegatedGroupIdsExistFor(EnrolmentKey("HMRC-MTD-IT", MtdItId("XAIT0000111122")), Set("foo"))
+            givenDelegatedGroupIdsNotExistFor(EnrolmentKey("HMRC-MTD-IT-SUPP", MtdItId("XAIT0000111122")))
+
+            val result = doAgentGetRequest(request.uri)
+            result.status shouldBe 200
+            result.json shouldBe Json.obj(
+              "name"                       -> "Erling Haal",
+              "isOverseas"                 -> false,
+              "knownFacts"                 -> Json.arr("AA1 1AA"),
+              "knownFactType"              -> "PostalCode",
+              "hasPendingInvitation"       -> false,
+              "hasExistingRelationshipFor" -> "HMRC-MTD-IT"
+            )
+          }
+
+          "the existing relationship is in a supporting role" in {
+            val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-IT/details/AA000001B")
+            givenAuthorisedAsValidAgent(request, "XARN1234567")
+            givenAuditConnector()
+            givenItsaBusinessDetailsExists("nino", "AA000001B")
+            givenItsaBusinessDetailsExists("mtdId", "XAIT0000111122")
+            givenAgentGroupExistsFor("foo")
+            givenAdminUser("foo", "bar")
+            givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+            givenDelegatedGroupIdsExistFor(EnrolmentKey("HMRC-MTD-IT-SUPP", MtdItId("XAIT0000111122")), Set("foo"))
+            givenDelegatedGroupIdsNotExistFor(EnrolmentKey("HMRC-MTD-IT", MtdItId("XAIT0000111122")))
+
+            val result = doAgentGetRequest(request.uri)
+            result.status shouldBe 200
+            result.json shouldBe Json.obj(
+              "name"                       -> "Erling Haal",
+              "isOverseas"                 -> false,
+              "knownFacts"                 -> Json.arr("AA1 1AA"),
+              "knownFactType"              -> "PostalCode",
+              "hasPendingInvitation"       -> false,
+              "hasExistingRelationshipFor" -> "HMRC-MTD-IT-SUPP"
+            )
+          }
+        }
+
+        "the service does not support multiple agents" in {
+          val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
+          givenAuthorisedAsValidAgent(request, "XARN1234567")
+          givenAuditConnector()
+          givenVatCustomerInfoExists("101747641")
+          givenAgentGroupExistsFor("foo")
+          givenAdminUser("foo", "bar")
+          givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+          givenDelegatedGroupIdsExistFor(EnrolmentKey("HMRC-MTD-VAT", Vrn("101747641")), Set("foo"))
+
+          val result = doAgentGetRequest(request.uri)
+          result.status shouldBe 200
+          result.json shouldBe Json.obj(
+            "name"                       -> "CFG Solutions",
+            "knownFacts"                 -> Json.arr("2020-01-01"),
+            "knownFactType"              -> "Date",
+            "hasPendingInvitation"       -> false,
+            "hasExistingRelationshipFor" -> "HMRC-MTD-VAT"
+          )
+        }
+      }
+
+      "the client has both a pending invitation and an existing relationship for this agent & service" in {
+        val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
+        givenAuthorisedAsValidAgent(request, "XARN1234567")
+        givenAuditConnector()
+        givenVatCustomerInfoExists("101747641")
+        givenAgentGroupExistsFor("foo")
+        givenAdminUser("foo", "bar")
+        givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+        givenDelegatedGroupIdsExistFor(EnrolmentKey("HMRC-MTD-VAT", Vrn("101747641")), Set("foo"))
+        await(repository.create("XARN1234567", Vat, Vrn("101747641"), Vrn("101747641"), "My Name", LocalDate.now()))
+
+        val result = doAgentGetRequest(request.uri)
+        result.status shouldBe 200
+        result.json shouldBe Json.obj(
+          "name"                       -> "CFG Solutions",
+          "knownFacts"                 -> Json.arr("2020-01-01"),
+          "knownFactType"              -> "Date",
+          "hasPendingInvitation"       -> true,
+          "hasExistingRelationshipFor" -> "HMRC-MTD-VAT"
+        )
+      }
     }
 
     "return 404 status when client details were not found" in {
-      val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-IT/details/AA000001B")
+      val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
       givenAuthorisedAsValidAgent(request, "XARN1234567")
       givenAuditConnector()
-      givenItsaBusinessDetailsError("AA000001B", NOT_FOUND)
-      givenItsaCitizenDetailsError("AA000001B", NOT_FOUND)
-      givenItsaDesignatoryDetailsError("AA000001B", NOT_FOUND)
+      givenVatCustomerInfoError("101747641", NOT_FOUND)
+      givenAgentGroupExistsFor("foo")
+      givenAdminUser("foo", "bar")
+      givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+      givenDelegatedGroupIdsExistFor(EnrolmentKey("HMRC-MTD-VAT", Vrn("101747641")), Set("foo"))
 
       val result = doAgentGetRequest(request.uri)
       result.status shouldBe 404
       result.body shouldBe empty
     }
 
-    "return 500 status when there was an unexpected failure" in {
-      val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-IT/details/AA000001B")
-      givenAuthorisedAsValidAgent(request, "XARN1234567")
-      givenAuditConnector()
-      givenItsaBusinessDetailsError("AA000001B", INTERNAL_SERVER_ERROR)
+    "return 500 status" when {
 
-      val result = doAgentGetRequest(request.uri)
-      result.status shouldBe 500
-      result.body shouldBe empty
+      "there was an unexpected failure retrieving client details" in {
+        val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
+        givenAuthorisedAsValidAgent(request, "XARN1234567")
+        givenAuditConnector()
+        givenVatCustomerInfoError("101747641", INTERNAL_SERVER_ERROR)
+        givenAgentGroupExistsFor("foo")
+        givenAdminUser("foo", "bar")
+        givenPrincipalGroupIdExistsFor(agentEnrolmentKey(Arn("XARN1234567")), "foo")
+        givenDelegatedGroupIdsExistFor(EnrolmentKey("HMRC-MTD-VAT", Vrn("101747641")), Set("foo"))
+
+        val result = doAgentGetRequest(request.uri)
+        result.status shouldBe 500
+      }
+
+      "there was an unexpected failure retrieving the existing relationships" in {
+        val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
+        givenAuthorisedAsValidAgent(request, "XARN1234567")
+        givenAuditConnector()
+        givenVatCustomerInfoExists("101747641")
+        givenAgentGroupExistsFor("foo")
+        givenAdminUser("foo", "bar")
+        givenPrincipalGroupIdRequestFailsWith(INTERNAL_SERVER_ERROR)
+        givenDelegatedGroupIdsExistFor(EnrolmentKey("HMRC-MTD-VAT", Vrn("101747641")), Set("foo"))
+
+        val result = doAgentGetRequest(request.uri)
+        result.status shouldBe 500
+      }
     }
 
-    "return 401 if the user is not authorised" in {
-      val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-IT/details/AA000001B")
+    "return 401 status if the user is not authorised" in {
+      val request = FakeRequest("GET", "/agent-client-relationships/client/HMRC-MTD-VAT/details/101747641")
       requestIsNotAuthenticated()
 
       val result = doAgentGetRequest(request.uri)

--- a/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ClientDetailsStub.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ClientDetailsStub.scala
@@ -70,9 +70,9 @@ trait ClientDetailsStub {
         .willReturn(aResponse().withStatus(status))
     )
 
-  def givenItsaBusinessDetailsExists(nino: String): StubMapping =
+  def givenItsaBusinessDetailsExists(idType: String, id: String): StubMapping =
     stubFor(
-      get(urlEqualTo(s"/registration/business-details/nino/$nino"))
+      get(urlEqualTo(s"/registration/business-details/$idType/$id"))
         .willReturn(
           aResponse()
             .withBody(s"""
@@ -86,7 +86,8 @@ trait ClientDetailsStub {
                          |          "countryCode": "GB"
                          |        }
                          |      }
-                         |    ]
+                         |    ],
+                         |    "mtdId": "XAIT0000111122"
                          |  }
                          |}
           """.stripMargin)

--- a/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ClientDetailsStub.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/stubs/ClientDetailsStub.scala
@@ -55,7 +55,10 @@ trait ClientDetailsStub {
                          |      "lastName": "Kovacic"
                          |    }
                          |  },
-                         |  "dateOfBirth": "01012000"
+                         |  "dateOfBirth": "01012000",
+                         |  "ids": {
+                         |    "sautr": "11223344"
+                         |  }
                          |}
           """.stripMargin)
         )

--- a/test/uk/gov/hmrc/agentclientrelationships/model/clientDetails/ClientDetailsResponseSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/model/clientDetails/ClientDetailsResponseSpec.scala
@@ -35,15 +35,19 @@ class ClientDetailsResponseSpec extends UnitSpec {
             Some(Insolvent),
             isOverseas = Some(true),
             Seq("test@email.com"),
-            Some(Email)
+            Some(Email),
+            hasPendingInvitation = true,
+            Some("HMRC-MTD-VAT")
           )
 
         val expectedJson = Json.obj(
-          "name"          -> "Ilkay Gundo",
-          "status"        -> "Insolvent",
-          "isOverseas"    -> true,
-          "knownFacts"    -> Json.arr("test@email.com"),
-          "knownFactType" -> "Email"
+          "name"                       -> "Ilkay Gundo",
+          "status"                     -> "Insolvent",
+          "isOverseas"                 -> true,
+          "knownFacts"                 -> Json.arr("test@email.com"),
+          "knownFactType"              -> "Email",
+          "hasPendingInvitation"       -> true,
+          "hasExistingRelationshipFor" -> "HMRC-MTD-VAT"
         )
 
         Json.toJson(model) shouldBe expectedJson
@@ -53,9 +57,10 @@ class ClientDetailsResponseSpec extends UnitSpec {
         val model = ClientDetailsResponse("Ilkay Gundo", None, isOverseas = Some(true), Seq(), None)
 
         val expectedJson = Json.obj(
-          "name"       -> "Ilkay Gundo",
-          "isOverseas" -> true,
-          "knownFacts" -> Json.arr()
+          "name"                 -> "Ilkay Gundo",
+          "isOverseas"           -> true,
+          "knownFacts"           -> Json.arr(),
+          "hasPendingInvitation" -> false
         )
 
         Json.toJson(model) shouldBe expectedJson

--- a/test/uk/gov/hmrc/agentclientrelationships/model/clientDetails/itsa/ItsaCitizenDetailsSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/model/clientDetails/itsa/ItsaCitizenDetailsSpec.scala
@@ -35,11 +35,14 @@ class ItsaCitizenDetailsSpec extends UnitSpec {
               "lastName"  -> "Kovacic"
             )
           ),
-          "dateOfBirth" -> "01012000"
+          "dateOfBirth" -> "01012000",
+          "ids" -> Json.obj(
+            "sautr" -> "11223344"
+          )
         )
 
         json.as[ItsaCitizenDetails] shouldBe
-          ItsaCitizenDetails(Some("Matthew"), Some("Kovacic"), Some(LocalDate.parse("2000-01-01")))
+          ItsaCitizenDetails(Some("Matthew"), Some("Kovacic"), Some(LocalDate.parse("2000-01-01")), Some("11223344"))
       }
 
       "optional fields are not present" in {
@@ -49,7 +52,7 @@ class ItsaCitizenDetailsSpec extends UnitSpec {
           )
         )
 
-        json.as[ItsaCitizenDetails] shouldBe ItsaCitizenDetails(None, None, None)
+        json.as[ItsaCitizenDetails] shouldBe ItsaCitizenDetails(None, None, None, None)
       }
     }
   }

--- a/test/uk/gov/hmrc/agentclientrelationships/services/ClientDetailsServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/services/ClientDetailsServiceSpec.scala
@@ -78,7 +78,9 @@ class ClientDetailsServiceSpec extends UnitSpec {
             when(mockConnector.getItsaBusinessDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
               .thenReturn(Future.successful(Left(ClientDetailsNotFound)))
             when(mockConnector.getItsaCitizenDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
-              .thenReturn(Future.successful(Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), None))))
+              .thenReturn(
+                Future.successful(Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), None, Some("11223344"))))
+              )
             when(mockConnector.getItsaDesignatoryDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
               .thenReturn(Future.successful(Right(ItsaDesignatoryDetails(Some("AA1 1AA")))))
 
@@ -93,7 +95,9 @@ class ClientDetailsServiceSpec extends UnitSpec {
             when(mockConnector.getItsaBusinessDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
               .thenReturn(Future.successful(Left(ClientDetailsNotFound)))
             when(mockConnector.getItsaCitizenDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
-              .thenReturn(Future.successful(Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), None))))
+              .thenReturn(
+                Future.successful(Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), None, Some("11223344"))))
+              )
             when(mockConnector.getItsaDesignatoryDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
               .thenReturn(Future.successful(Right(ItsaDesignatoryDetails(None))))
 
@@ -105,7 +109,19 @@ class ClientDetailsServiceSpec extends UnitSpec {
             when(mockConnector.getItsaBusinessDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
               .thenReturn(Future.successful(Left(ClientDetailsNotFound)))
             when(mockConnector.getItsaCitizenDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
-              .thenReturn(Future.successful(Right(ItsaCitizenDetails(None, None, None))))
+              .thenReturn(Future.successful(Right(ItsaCitizenDetails(None, None, None, Some("11223344")))))
+            when(mockConnector.getItsaDesignatoryDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
+              .thenReturn(Future.successful(Right(ItsaDesignatoryDetails(Some("AA1 1AA")))))
+
+            await(service.findClientDetails("HMRC-MTD-IT", "AA000001B")) shouldBe Left(ClientDetailsNotFound)
+          }
+
+          "return a ClientDetailsNotFound error if no SA UTR was returned" in {
+            when(mockAppConfig.altItsaEnabled).thenReturn(true)
+            when(mockConnector.getItsaBusinessDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
+              .thenReturn(Future.successful(Left(ClientDetailsNotFound)))
+            when(mockConnector.getItsaCitizenDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
+              .thenReturn(Future.successful(Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), None, None))))
             when(mockConnector.getItsaDesignatoryDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
               .thenReturn(Future.successful(Right(ItsaDesignatoryDetails(Some("AA1 1AA")))))
 
@@ -215,7 +231,7 @@ class ClientDetailsServiceSpec extends UnitSpec {
           when(mockConnector.getItsaCitizenDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
             .thenReturn(
               Future.successful(
-                Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), Some(LocalDate.parse("2000-01-01"))))
+                Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), Some(LocalDate.parse("2000-01-01")), None))
               )
             )
 
@@ -227,14 +243,16 @@ class ClientDetailsServiceSpec extends UnitSpec {
 
         "return a ClientDetailsNotFound error if no date of birth was returned" in {
           when(mockConnector.getItsaCitizenDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
-            .thenReturn(Future.successful(Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), None))))
+            .thenReturn(Future.successful(Right(ItsaCitizenDetails(Some("John"), Some("Rocks"), None, None))))
 
           await(service.findClientDetails("PERSONAL-INCOME-RECORD", "AA000001B")) shouldBe Left(ClientDetailsNotFound)
         }
 
         "return a ClientDetailsNotFound error if no name was returned" in {
           when(mockConnector.getItsaCitizenDetails(eqTo[String]("AA000001B"))(any[HeaderCarrier]))
-            .thenReturn(Future.successful(Right(ItsaCitizenDetails(None, None, Some(LocalDate.parse("2000-01-01"))))))
+            .thenReturn(
+              Future.successful(Right(ItsaCitizenDetails(None, None, Some(LocalDate.parse("2000-01-01")), None)))
+            )
 
           await(service.findClientDetails("PERSONAL-INCOME-RECORD", "AA000001B")) shouldBe Left(ClientDetailsNotFound)
         }


### PR DESCRIPTION
I've added "NINO" to the case match in RelationshipsController so that the `enrolmentId` value could be used for all tax types. Currently, agent-invitations-frontend has a helper function which converts this from "NINO" to "NI" solely for income tax (it also has a TODO questioning why). It seemed better to me to update this case match rather than re-implementing that func here.