### PR TITLE
APB-8955 WIP, implemented main accept pipeline

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/config/AppConfig.scala
@@ -115,7 +115,7 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
     servicesConfig.getBoolean("alt-itsa.enabled")
 
   // Note: Personal Income Record is not handled through agent-client-relationships
-  val supportedServices: Seq[Service] = Service.supportedServices.filterNot(_ == Service.PersonalIncomeRecord)
+  val supportedServices: Seq[Service] = Service.supportedServices
   // TODO: Keeping this list in appConfig to enable reading it from config in future if necessary
   // If this is not needed, could be moved somewhere else where constants are kept
 

--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/AuthorisationAcceptController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/AuthorisationAcceptController.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.controllers
+
+import play.api.Logging
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.agentclientrelationships.audit.{AuditData, AuditService}
+import uk.gov.hmrc.agentclientrelationships.auth.AuthActions
+import uk.gov.hmrc.agentclientrelationships.config.AppConfig
+import uk.gov.hmrc.agentclientrelationships.model.Pending
+import uk.gov.hmrc.agentclientrelationships.model.invitation.InvitationFailureResponse.ErrorBody
+import uk.gov.hmrc.agentclientrelationships.services.{AuthorisationAcceptService, CreateRelationshipLocked, InvitationService, ValidationService}
+import uk.gov.hmrc.agentmtdidentifiers.model.{ClientIdType, Service}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.InternalServerException
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AuthorisationAcceptController @Inject() (
+  invitationService: InvitationService,
+  authorisationAcceptService: AuthorisationAcceptService,
+  validationService: ValidationService,
+  auditService: AuditService,
+  val authConnector: AuthConnector,
+  val appConfig: AppConfig,
+  cc: ControllerComponents
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc)
+    with AuthActions
+    with Logging {
+
+  val supportedServices: Seq[Service] = appConfig.supportedServices
+
+  private val strideRoles = Seq(appConfig.oldAuthStrideRole, appConfig.newAuthStrideRole)
+
+  def accept(invitationId: String): Action[AnyContent] = Action.async { implicit request =>
+    invitationService.findInvitation(invitationId).flatMap {
+      case Some(invitation) if invitation.status == Pending =>
+        implicit val auditData: AuditData = new AuditData()
+        auditData.set("arn", invitation.arn)
+        for {
+          enrolment <-
+            validationService
+              .validateForEnrolmentKey(
+                invitation.service,
+                ClientIdType.forId(invitation.clientIdType).enrolmentId,
+                invitation.clientId
+              )
+              .map(either =>
+                either.getOrElse(
+                  throw new InternalServerException(
+                    s"Could not parse invitation details into enrolment reason: ${either.left}"
+                  )
+                )
+              )
+          result <-
+            authorisedUser(None, enrolment.oneTaxIdentifier(), strideRoles) { implicit currentUser =>
+              authorisationAcceptService
+                .accept(invitation, enrolment)
+                .map(_ => NoContent)
+                .recoverWith {
+                  case CreateRelationshipLocked => Future.successful(Locked)
+                  case err                      => throw err
+                }
+            }
+          // non blocking email request
+          // non blocking friendly name update
+          // audit
+        } yield result
+      case Some(_) =>
+        Future.successful(
+          Forbidden(
+            Json.toJson(
+              ErrorBody("INVALID_INVITATION_STATUS", "Invitation cannot be accepted because it is not Pending")
+            )
+          )
+        )
+      case _ =>
+        Future.successful(
+          NotFound(Json.toJson(ErrorBody("INVITATION_NOT_FOUND", "The specified invitation was not found.")))
+        )
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/AuthorisationRequestInfoController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/AuthorisationRequestInfoController.scala
@@ -46,7 +46,7 @@ class AuthorisationRequestInfoController @Inject() (
 
   def get(arn: Arn, invitationId: String): Action[AnyContent] = Action.async { implicit request =>
     withAuthorisedAsAgent { _ =>
-      invitationService.findInvitation(arn.value, invitationId).flatMap {
+      invitationService.findInvitationForAgent(arn.value, invitationId).flatMap {
         case Some(invitation) =>
           for {
             agentLink    <- invitationLinkService.createLink(arn)

--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsController.scala
@@ -119,7 +119,7 @@ class RelationshipsController @Inject() (
         case Right(enrolmentKey) =>
           val taxIdentifier =
             enrolmentKey.oneTaxIdentifier()
-          authorisedUser(arn, taxIdentifier, strideRoles) { implicit currentUser =>
+          authorisedUser(Some(arn), taxIdentifier, strideRoles) { implicit currentUser =>
             (for {
               maybeEk <- taxIdentifier match {
                            // turn a NINO-based enrolment key for IT into a MtdItId-based one if necessary

--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/RemoveAuthorisationController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/RemoveAuthorisationController.scala
@@ -130,7 +130,7 @@ class RemoveAuthorisationController @Inject() (
       result <- EitherT.right[InvitationFailureResponse] {
 
                   authorisedUser(
-                    arn = arn,
+                    arn = Some(arn),
                     clientId = enrolmentKey.oneTaxIdentifier(),
                     strideRoles = Seq(appConfig.oldAuthStrideRole, appConfig.newAuthStrideRole)
                   ) { implicit currentUser =>

--- a/app/uk/gov/hmrc/agentclientrelationships/services/AuthorisationAcceptService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/AuthorisationAcceptService.scala
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.services
+
+import play.api.Logging
+import play.api.mvc.Request
+import uk.gov.hmrc.agentclientrelationships.audit.AuditData
+import uk.gov.hmrc.agentclientrelationships.auth.CurrentUser
+import uk.gov.hmrc.agentclientrelationships.config.AppConfig
+import uk.gov.hmrc.agentclientrelationships.connectors.AgentFiRelationshipConnector
+import uk.gov.hmrc.agentclientrelationships.model._
+import uk.gov.hmrc.agentclientrelationships.repository.InvitationsRepository.endedByClient
+import uk.gov.hmrc.agentclientrelationships.repository.{InvitationsRepository, PartialAuthRepository}
+import uk.gov.hmrc.agentmtdidentifiers.model.Service.{HMRCMTDIT, HMRCMTDITSUPP, HMRCPIR}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId, MtdItIdType, Service}
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.time.{Instant, LocalDateTime, ZoneId}
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class AuthorisationAcceptService @Inject() (
+  appConfig: AppConfig,
+  relationshipsService: CreateRelationshipsService,
+  checkRelationshipsOrchestratorService: CheckRelationshipsOrchestratorService,
+  deleteRelationshipsService: DeleteRelationshipsServiceWithAcr,
+  invitationsRepository: InvitationsRepository,
+  partialAuthRepository: PartialAuthRepository,
+  agentFiRelationshipConnector: AgentFiRelationshipConnector
+)(implicit ec: ExecutionContext)
+    extends Logging {
+
+  def accept(
+    invitation: Invitation,
+    enrolment: EnrolmentKey
+  )(implicit
+    hc: HeaderCarrier,
+    request: Request[_],
+    currentUser: CurrentUser,
+    auditData: AuditData
+  ) = {
+    val timestamp = Instant.now
+    val isAltItsa = Seq(HMRCMTDIT, HMRCMTDITSUPP).contains(invitation.service) &&
+      invitation.clientId == invitation.suppliedClientId
+    val nextStatus = if (isAltItsa) PartialAuth else Accepted
+    for {
+      _ <- manuallyDeleteSameAgentRelationship(invitation, isAltItsa)
+      // Create relationship
+      _ <- createRelationship(invitation, enrolment, isAltItsa, timestamp)
+      // Create partial auth if alt itsa
+      _ <- if (isAltItsa)
+             partialAuthRepository.create(timestamp, Arn(invitation.arn), invitation.service, Nino(invitation.clientId))
+           else Future.unit
+      // Update invitation
+      updated <- invitationsRepository.updateStatus(invitation.invitationId, nextStatus, Some(timestamp))
+      // Deauth old invitations (putting a Future into a successful Future creates a non-blocking thread and lets the code continue)
+      _ <- Future.successful(deauthExistingInvitations(invitation, isAltItsa, timestamp))
+    } yield updated
+  }
+
+  private def manuallyDeleteSameAgentRelationship(invitation: Invitation, isAltItsa: Boolean)(implicit
+    hc: HeaderCarrier,
+    currentUser: CurrentUser,
+    request: Request[_]
+  ) =
+    invitation.service match {
+      case `HMRCMTDIT` | `HMRCMTDITSUPP` if isAltItsa =>
+        // val serviceToCheck = Service.forId(if (invitation.service == HMRCMTDIT) HMRCMTDITSUPP else HMRCMTDIT)
+        // TODO update existing partial auth to deauth
+        Future.unit
+      case `HMRCMTDIT` | `HMRCMTDITSUPP` =>
+        val serviceToCheck = Service.forId(if (invitation.service == HMRCMTDIT) HMRCMTDITSUPP else HMRCMTDIT)
+        checkRelationshipsOrchestratorService
+          .checkForRelationship(
+            Arn(invitation.arn),
+            serviceToCheck.id,
+            MtdItIdType.enrolmentId,
+            invitation.clientId,
+            None
+          )
+          .flatMap {
+            case CheckRelationshipFound =>
+              deleteRelationshipsService.deleteRelationship(
+                Arn(invitation.arn),
+                EnrolmentKey(
+                  serviceToCheck,
+                  MtdItId(invitation.clientId)
+                ),
+                None // TODO Fix
+              )
+            case _ => Future.unit
+          }
+      case _ => Future.unit
+    }
+
+  private def createRelationship(
+    invitation: Invitation,
+    enrolment: EnrolmentKey,
+    isAltItsa: Boolean,
+    timestamp: Instant
+  )(implicit
+    hc: HeaderCarrier,
+    auditData: AuditData
+  ) =
+    invitation.service match {
+      case _ if isAltItsa => Future.unit
+      case `HMRCPIR` =>
+        agentFiRelationshipConnector.createRelationship(
+          Arn(invitation.arn),
+          invitation.service,
+          invitation.clientId,
+          LocalDateTime.ofInstant(timestamp, ZoneId.systemDefault)
+        )
+      case _ =>
+        relationshipsService
+          .createRelationship(
+            Arn(invitation.arn),
+            enrolment,
+            Set(),
+            failIfCreateRecordFails = false,
+            failIfAllocateAgentInESFails = true
+          )
+          .map(_.getOrElse(throw CreateRelationshipLocked))
+    }
+
+  private def deauthExistingInvitations(invitation: Invitation, isAltItsa: Boolean, timestamp: Instant) = {
+    val acceptedStatus = if (isAltItsa) PartialAuth else Accepted
+    (invitation.service match {
+      case `HMRCMTDIT` => // Deauth any `main` agents and only same arn `supp` agents
+        for {
+          supp <- invitationsRepository
+                    .findAllBy(
+                      arn = Some(invitation.arn),
+                      services = Seq(HMRCMTDITSUPP),
+                      clientId = Some(invitation.clientId),
+                      status = Some(acceptedStatus)
+                    )
+                    .fallbackTo(Future.successful(Nil))
+          main <- invitationsRepository
+                    .findAllBy(
+                      services = Seq(HMRCMTDIT),
+                      clientId = Some(invitation.clientId),
+                      status = Some(acceptedStatus)
+                    )
+                    .fallbackTo(Future.successful(Nil))
+        } yield supp ++ main
+      case `HMRCMTDITSUPP` => // Deauth only same arn `main`/`supp` agents
+        invitationsRepository
+          .findAllBy(
+            arn = Some(invitation.arn),
+            services = Seq(HMRCMTDITSUPP, HMRCMTDIT),
+            clientId = Some(invitation.clientId),
+            status = Some(acceptedStatus)
+          )
+          .fallbackTo(Future.successful(Nil))
+      case _ => // Deauth any `main` agent
+        invitationsRepository
+          .findAllBy(
+            services = Seq(invitation.service),
+            clientId = Some(invitation.clientId),
+            status = Some(acceptedStatus)
+          )
+          .fallbackTo(Future.successful(Nil))
+    })
+      .map { acceptedInvitations: Seq[Invitation] =>
+        acceptedInvitations
+          .filterNot(_.invitationId == invitation.invitationId)
+          .foreach(acceptedInvitation =>
+            invitationsRepository.deauthInvitation(acceptedInvitation.invitationId, endedByClient, Some(timestamp))
+          )
+      }
+  }
+
+}
+
+sealed trait AuthorisationResponseError extends Exception
+case object CreateRelationshipLocked extends AuthorisationResponseError

--- a/app/uk/gov/hmrc/agentclientrelationships/services/CheckRelationshipsOrchestratorService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/CheckRelationshipsOrchestratorService.scala
@@ -61,6 +61,7 @@ class CheckRelationshipsOrchestratorService @Inject() (
     (service, clientIdType, clientId) match {
       // Used by BTA to handle non MTD ITSA users
       case ("IR-SA", _, _) if Nino.isValid(clientId) =>
+        // TODO make sure this checks partial auth on ACR instead of ACA
         withIrSaSuspensionCheck(arn) {
           checkLegacyWithNinoOrPartialAuth(arn, Nino(clientId))
         }

--- a/app/uk/gov/hmrc/agentclientrelationships/services/InvitationService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/InvitationService.scala
@@ -61,8 +61,11 @@ class InvitationService @Inject() (
     invitationT.value
   }
 
-  def findInvitation(arn: String, invitationId: String): Future[Option[Invitation]] =
-    invitationsRepository.findOneById(arn, invitationId)
+  def findInvitationForAgent(arn: String, invitationId: String): Future[Option[Invitation]] =
+    invitationsRepository.findOneByIdForAgent(arn, invitationId)
+
+  def findInvitation(invitationId: String): Future[Option[Invitation]] =
+    invitationsRepository.findOneById(invitationId)
 
   def rejectInvitation(
     invitationId: String

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -26,6 +26,7 @@ GET           /agent/:arn/authorisation-request-info/:invitationId           @uk
 # TODO agree the response for and implement the GET all route
 # GET           /agent/:arn/authorisation-request-info                         @uk.gov.hmrc.agentclientrelationships.controllers.AuthorisationRequestInfoController.getAll
 POST          /agent/:arn/remove-authorisation                              @uk.gov.hmrc.agentclientrelationships.controllers.RemoveAuthorisationController.removeAuthorisation(arn: uk.gov.hmrc.agentmtdidentifiers.model.Arn)
+PUT           /authorisation-response/accept/:invitationId                   @uk.gov.hmrc.agentclientrelationships.controllers.AuthorisationAcceptController.accept(invitationId: String)
 
 # stride endpoints
 GET           /relationships/service/:service/client/:clientIdType/:clientId @uk.gov.hmrc.agentclientrelationships.controllers.RelationshipsController.getRelationships(service: String, clientIdType: String, clientId: String)


### PR DESCRIPTION
Still missing partial-auth deauth (when agent switches main-supp), email logic, friendly name update and unit/it testing. Code is manually validated for all types of invitations, including agent switching from main to supp and vice versa.

Missing things to be done with separate PR, this one is intended to unblock the frontend.