### PR TITLE
APB-9152 Add new endpoint for customer-status

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/auth/AuthActions.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/auth/AuthActions.scala
@@ -177,6 +177,14 @@ trait AuthActions extends AuthorisedFunctions with Logging {
         }
       }
 
+  def withAuthorisedAsClientForStatus(
+    body: EnrolmentsWithNino => Future[Result]
+  )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Result] =
+    authorised(AuthProviders(GovernmentGateway) and (Individual or Organisation))
+      .retrieve(allEnrolments and nino) { case enrolments ~ nino =>
+        body(new EnrolmentsWithNino(enrolments, nino))
+      }
+
   protected def authorisedWithStride(oldStrideRole: String, newStrideRole: String)(
     body: String => Future[Result]
   )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[Result] =

--- a/app/uk/gov/hmrc/agentclientrelationships/controllers/CustomerStatusController.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/controllers/CustomerStatusController.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.controllers
+
+import play.api.libs.json.Json
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.agentclientrelationships.auth.AuthActions
+import uk.gov.hmrc.agentclientrelationships.config.AppConfig
+import uk.gov.hmrc.agentclientrelationships.model.{CustomerStatus, EnrolmentsWithNino, Pending}
+import uk.gov.hmrc.agentclientrelationships.repository.{InvitationsRepository, PartialAuthRepository}
+import uk.gov.hmrc.agentclientrelationships.services.FindRelationshipsService
+import uk.gov.hmrc.agentmtdidentifiers.model.Service
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class CustomerStatusController @Inject()(findRelationshipsService: FindRelationshipsService,
+                                         invitationsRepository: InvitationsRepository,
+                                         partialAuthRepository: PartialAuthRepository,
+                                         val authConnector: AuthConnector,
+                                         appConfig: AppConfig,
+                                         cc: ControllerComponents
+                                        )(implicit ec: ExecutionContext)
+  extends BackendController(cc) with AuthActions {
+
+  val supportedServices: Seq[Service] = appConfig.supportedServices
+
+  def customerStatus: Action[AnyContent] = Action.async { implicit request =>
+    withAuthorisedAsClientForStatus { authResponse: EnrolmentsWithNino =>
+      val services = authResponse.getIdentifierMap(supportedServices).keys.toSeq.map(_.id)
+      val identifiers = authResponse.getIdentifierMap(supportedServices).values.toSeq.map(_.value)
+      for {
+        invitations <- invitationsRepository.findAllBy(None, services, identifiers, None)
+        partialAuthRecord <- authResponse.getNino match {
+          case Some(ni) => partialAuthRepository.findByNino(Nino(ni))
+          case None => Future.successful(None)
+        }
+        existingRelationships <- if(partialAuthRecord.exists(_.active == true)) {
+          Future.successful(true)
+        } else {
+          findRelationshipsService.getActiveRelationshipsForClient(authResponse.getIdentifierMap(supportedServices))
+            .map(_.nonEmpty)
+        }
+      } yield {
+        Ok(Json.toJson(CustomerStatus(
+          hasPendingInvitations = invitations.exists(_.status == Pending),
+          hasInvitationsHistory = invitations.nonEmpty || partialAuthRecord.nonEmpty,
+          hasExistingRelationships = existingRelationships
+        )))
+      }
+    }
+  }
+}
+

--- a/app/uk/gov/hmrc/agentclientrelationships/model/CustomerStatus.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/model/CustomerStatus.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.model
+
+import play.api.libs.json.{Json, OWrites}
+
+case class CustomerStatus(hasPendingInvitations: Boolean,
+                          hasInvitationsHistory: Boolean,
+                          hasExistingRelationships: Boolean)
+
+object CustomerStatus {
+  implicit val writes: OWrites[CustomerStatus] = Json.writes[CustomerStatus]
+}

--- a/app/uk/gov/hmrc/agentclientrelationships/model/EnrolmentsWithNino.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/model/EnrolmentsWithNino.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.model
+
+import uk.gov.hmrc.agentmtdidentifiers.model.Service
+import uk.gov.hmrc.auth.core.Enrolments
+import uk.gov.hmrc.domain.TaxIdentifier
+
+class EnrolmentsWithNino(enrolments: Enrolments, nino: Option[String]) {
+
+  private val ptNino: Option[String] =
+    enrolments.enrolments.find(_.key == "HMRC-PT").flatMap(_.identifiers.headOption.map(_.value))
+
+  def getNino: Option[String] = ptNino.orElse(nino)
+
+  def getIdentifierMap(supportedServices: Seq[Service]): Map[Service, TaxIdentifier] = {
+    val identifiers = for {
+      supportedService <- supportedServices
+      enrolment        <- enrolments.getEnrolment(supportedService.enrolmentKey)
+      clientId         <- enrolment.identifiers.headOption
+    } yield (supportedService, supportedService.supportedClientIdType.createUnderlying(clientId.value))
+
+    identifiers.toMap
+  }
+}

--- a/app/uk/gov/hmrc/agentclientrelationships/repository/InvitationsRepository.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/repository/InvitationsRepository.scala
@@ -33,7 +33,6 @@ import java.time.{Instant, LocalDate}
 import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
 
 @Singleton
 class InvitationsRepository @Inject() (mongoComponent: MongoComponent, appConfig: AppConfig)(implicit

--- a/app/uk/gov/hmrc/agentclientrelationships/repository/PartialAuthRepository.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/repository/PartialAuthRepository.scala
@@ -46,7 +46,8 @@ class PartialAuthRepository @Inject() (mongoComponent: MongoComponent)(implicit 
             .partialFilterExpression(BsonDocument("active" -> true))
             .unique(true)
             .name("activeRelationshipsIndex")
-        )
+        ),
+        IndexModel(Indexes.ascending("nino"))
       ),
       replaceIndexes = true
     )
@@ -89,6 +90,9 @@ class PartialAuthRepository @Inject() (mongoComponent: MongoComponent)(implicit 
         )
       )
       .headOption()
+
+  def findByNino(nino: Nino): Future[Option[PartialAuthRelationship]] =
+    collection.find(equal("nino", nino.value)).headOption()
 
   /* this will only find partially authorised ITSA main agents for a given nino string */
   def findMainAgent(nino: String): Future[Option[PartialAuthRelationship]] =

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -32,6 +32,8 @@ POST          /itsa-post-signup/create-relationship/:nino                    @uk
 
 POST          /invitations/trusts-enrolment-orchestrator/:urn/update         @uk.gov.hmrc.agentclientrelationships.controllers.InvitationController.replaceUrnWithUtr(urn: String)
 
+GET           /customer-status                                               @uk.gov.hmrc.agentclientrelationships.controllers.CustomerStatusController.customerStatus
+
 # stride endpoints
 GET           /relationships/service/:service/client/:clientIdType/:clientId @uk.gov.hmrc.agentclientrelationships.controllers.RelationshipsController.getRelationships(service: String, clientIdType: String, clientId: String)
 

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/CustomerStatusControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/CustomerStatusControllerISpec.scala
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.controllers
+
+import play.api.http.Status.{NOT_FOUND, OK, UNAUTHORIZED}
+import play.api.libs.json.Json
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.agentclientrelationships.model.{CustomerStatus, Invitation, PartialAuthRelationship, Pending}
+import uk.gov.hmrc.agentclientrelationships.repository.{InvitationsRepository, PartialAuthRepository}
+import uk.gov.hmrc.agentclientrelationships.stubs.HIPAgentClientRelationshipStub
+
+import java.time.temporal.ChronoUnit
+import java.time.{Instant, LocalDate}
+
+class CustomerStatusControllerISpec extends BaseControllerISpec with HIPAgentClientRelationshipStub {
+
+  val invitationsRepo: InvitationsRepository = app.injector.instanceOf[InvitationsRepository]
+  val partialAuthRepo: PartialAuthRepository = app.injector.instanceOf[PartialAuthRepository]
+  val pendingInvitation: Invitation = Invitation(
+    "123",
+    arn.value,
+    "HMRC-MTD-IT",
+    mtdItId.value,
+    "MTDITID",
+    mtdItId.value,
+    "MTDITID",
+    "Macrosoft",
+    Pending,
+    None,
+    Some("personal"),
+    LocalDate.parse("2020-01-01"),
+    Instant.now().truncatedTo(ChronoUnit.SECONDS),
+    Instant.now().truncatedTo(ChronoUnit.SECONDS)
+  )
+  val partialAuthRelationship: PartialAuthRelationship = PartialAuthRelationship(
+    Instant.now().truncatedTo(ChronoUnit.SECONDS),
+    arn.value,
+    "HMRC-MTD-IT",
+    nino.value,
+    active = true,
+    Instant.now().truncatedTo(ChronoUnit.SECONDS)
+  )
+  val inactivePartialAuthRelationship: PartialAuthRelationship = partialAuthRelationship.copy(active = false)
+
+  ".customerStatus" should {
+
+    lazy val request = FakeRequest("GET", "/agent-client-relationships/customer-status")
+
+    "return 200 and the expected customer status JSON body" when {
+
+      "there are pending invitations and an active relationship from partial auth" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        await(invitationsRepo.collection.insertOne(pendingInvitation).toFuture())
+        await(partialAuthRepo.collection.insertOne(partialAuthRelationship).toFuture())
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = true, hasInvitationsHistory = true, hasExistingRelationships = true
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+
+      "there are pending invitations and an existing relationship from HODs" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        getActiveRelationshipsViaClient(mtdItId, arn)
+        await(invitationsRepo.collection.insertOne(pendingInvitation).toFuture())
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = true, hasInvitationsHistory = true, hasExistingRelationships = true
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+
+      "there are pending invitations and no existing relationship" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        getActiveRelationshipFailsWith(mtdItId, NOT_FOUND)
+        await(invitationsRepo.collection.insertOne(pendingInvitation).toFuture())
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = true, hasInvitationsHistory = true, hasExistingRelationships = false
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+
+      "there are no pending invitations and an active relationship from partial auth" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        await(partialAuthRepo.collection.insertOne(partialAuthRelationship).toFuture())
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = false, hasInvitationsHistory = true, hasExistingRelationships = true
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+
+      "there are no pending invitations, inactive partial auth and an existing relationship from HODs" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        getActiveRelationshipsViaClient(mtdItId, arn)
+        await(partialAuthRepo.collection.insertOne(inactivePartialAuthRelationship).toFuture())
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = false, hasInvitationsHistory = true, hasExistingRelationships = true
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+
+      "there are no pending invitations, no partial auth history and an existing relationship from HODs" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        getActiveRelationshipsViaClient(mtdItId, arn)
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = false, hasInvitationsHistory = false, hasExistingRelationships = true
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+
+      "there are no pending invitations, inactive partial auth and no existing relationships" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        getActiveRelationshipFailsWith(mtdItId, NOT_FOUND)
+        await(partialAuthRepo.collection.insertOne(inactivePartialAuthRelationship).toFuture())
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = false, hasInvitationsHistory = true, hasExistingRelationships = false
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+
+      "there are no pending invitations, no partial auth history and no existing relationships" in {
+        givenAuditConnector()
+        givenAuthorisedItsaClientWithNino(request, mtdItId, nino)
+        getActiveRelationshipFailsWith(mtdItId, NOT_FOUND)
+        val expectedBody = Json.toJson(CustomerStatus(
+          hasPendingInvitations = false, hasInvitationsHistory = false, hasExistingRelationships = false
+        ))
+
+        val result = doGetRequest(request.uri)
+        result.status shouldBe OK
+        result.json shouldBe expectedBody
+      }
+    }
+
+    "return 401 when the request is not authorised as a client" in {
+      givenAuthorisedAsValidAgent(request, arn.value)
+      val result = doGetRequest(request.uri)
+      result.status shouldBe UNAUTHORIZED
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/agentclientrelationships/repository/PartialAuthRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/repository/PartialAuthRepositoryISpec.scala
@@ -138,6 +138,18 @@ class PartialAuthRepositoryISpec
     }
   }
 
+  ".findByNino" should {
+
+    "retrieve a record for a given nino" in {
+      await(repo.collection.insertOne(partialAuth).toFuture())
+      await(repo.findByNino(Nino("SX579189D"))) shouldBe Some(partialAuth)
+    }
+
+    "fail to retrieve records when none are found for the given nino" in {
+      await(repo.findByNino(Nino("AA111111A"))) shouldBe None
+    }
+  }
+
   "deauthorise" should {
     "deauthorise PartialAuth invitation success" in {
       await(

--- a/it/test/uk/gov/hmrc/agentclientrelationships/stubs/AuthStub.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/stubs/AuthStub.scala
@@ -518,6 +518,29 @@ trait AuthStub {
     request.withHeaders(SessionKeys.authToken -> "Bearer XYZ")
   }
 
+  def givenAuthorisedItsaClientWithNino(request: FakeRequest[?], mtdItId: MtdItId, nino: Nino): FakeRequest[?] = {
+    givenAuthorisedFor(
+      Json.obj("retrieve" -> Json.arr("allEnrolments", "nino")).toString,
+      Json
+        .obj(
+          "allEnrolments" -> Json.arr(
+            Json.obj(
+              "key"         -> "HMRC-MTD-IT",
+              "identifiers" -> Json.arr(Json.obj("key" -> "MTDITID", "value" -> mtdItId))
+            ),
+            Json.obj(
+              "key"         -> "HMRC-PT",
+              "identifiers" -> Json.arr(Json.obj("key" -> "NINO", "value" -> nino))
+            )
+          ),
+          "nino" -> nino.value
+        )
+        .toString
+    )
+
+    request.withHeaders(SessionKeys.authToken -> "Bearer XYZ")
+  }
+
   def givenAuthorisedAsValidAgent[A](request: FakeRequest[A], arn: String) =
     authenticatedAgent(request, Enrolment("HMRC-AS-AGENT", "AgentReferenceNumber", arn))
 

--- a/test/uk/gov/hmrc/agentclientrelationships/model/CustomerStatusSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/model/CustomerStatusSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.model
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.agentclientrelationships.support.UnitSpec
+
+class CustomerStatusSpec extends UnitSpec {
+
+  "CustomerStatus" should {
+
+    "write to JSON" in {
+      val model =
+        CustomerStatus(hasPendingInvitations = true, hasInvitationsHistory = true, hasExistingRelationships = true)
+      val json = Json.obj(
+        "hasPendingInvitations" -> true,
+        "hasInvitationsHistory" -> true,
+        "hasExistingRelationships" -> true
+      )
+
+      Json.toJson(model) shouldBe json
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationships/model/EnrolmentsWithNinoSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/model/EnrolmentsWithNinoSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentclientrelationships.model
+
+import uk.gov.hmrc.agentclientrelationships.support.UnitSpec
+import uk.gov.hmrc.agentmtdidentifiers.model.Service.{MtdIt, Vat}
+import uk.gov.hmrc.agentmtdidentifiers.model.{MtdItId, Vrn}
+import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments}
+
+class EnrolmentsWithNinoSpec extends UnitSpec {
+
+  val nino = "AA111111A"
+  val mtdItId = "XAIT1234567"
+  val vrn = "123456789"
+  val ptEnrolment: Enrolment = Enrolment("HMRC-PT", Seq(EnrolmentIdentifier("NINO", nino)), "active")
+  val itsaEnrolment: Enrolment = Enrolment("HMRC-MTD-IT", Seq(EnrolmentIdentifier("MTDITID", mtdItId)), "active")
+  val vatEnrolment: Enrolment = Enrolment("HMRC-MTD-VAT", Seq(EnrolmentIdentifier("VRN", vrn)), "active")
+
+  ".getNino" should {
+
+    "return the NINO from the HMRC-PT enrolment if it exists" in {
+      val model = new EnrolmentsWithNino(Enrolments(Set(ptEnrolment)), Some(nino))
+      model.getNino shouldBe Some(nino)
+    }
+
+    "return the NINO from the model (auth retrieval) if the HMRC-PT enrolment does not exist" in {
+      val model = new EnrolmentsWithNino(Enrolments(Set()), Some(nino))
+      model.getNino shouldBe Some(nino)
+    }
+
+    "return None if both NINO sources were empty" in {
+      val model = new EnrolmentsWithNino(Enrolments(Set()), None)
+      model.getNino shouldBe None
+    }
+  }
+
+  ".getIdentifierMap" should {
+
+    "return a Map of services and tax identifiers for the provided supported services" in {
+      val model = new EnrolmentsWithNino(Enrolments(Set(ptEnrolment, itsaEnrolment, vatEnrolment)), Some(nino))
+      val supportedServices = Seq(MtdIt, Vat)
+      val expectedMap = Map(MtdIt -> MtdItId(mtdItId), Vat -> Vrn(vrn))
+
+      model.getIdentifierMap(supportedServices) shouldBe expectedMap
+    }
+
+    "return an empty Map when no enrolments match the supported services" in {
+      val model = new EnrolmentsWithNino(Enrolments(Set(ptEnrolment)), Some(nino))
+      val supportedServices = Seq(MtdIt, Vat)
+      val expectedMap = Map()
+
+      model.getIdentifierMap(supportedServices) shouldBe expectedMap
+    }
+  }
+}

--- a/test/uk/gov/hmrc/agentclientrelationships/support/UnitSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/support/UnitSpec.scala
@@ -35,7 +35,7 @@ trait UnitSpec extends AnyWordSpecLike with Matchers with OptionValues with Scal
   def status(result: Result): Int = result.header.status
   def status(result: Future[Result]): Int = Helpers.status(result)
   def bodyOf(result: Result): String = Helpers.contentAsString(Future.successful(result))
-  def redirectLocation(result: Result) = Helpers.redirectLocation(Future.successful(result))
+  def redirectLocation(result: Result): Option[String] = Helpers.redirectLocation(Future.successful(result))
   def contentAsString(result: Result): String = Helpers.contentAsString(Future.successful(result))
   def contentAsJson(result: Result): JsValue = Helpers.contentAsJson(Future.successful(result))
   def contentType(result: Result): Option[String] =
@@ -50,7 +50,7 @@ trait UnitSpec extends AnyWordSpecLike with Matchers with OptionValues with Scal
   def verifySideEffectsOccur(assertion: Unit => Any*): Seq[Assertion] =
     eventually(timeout(Span(5, Seconds)), interval(Span(50, Millis))) {
       assertion.map { func =>
-        noException should be thrownBy func()
+        noException should be thrownBy func
       }
     }
 }


### PR DESCRIPTION
Had to add a new auth action to enable me to use the nino retrieval and also prevent HMRC-PT enrolment from being filtered out by supported services list.