### PR TITLE
APB-9404 Protect DB call for MYTA page with no IDs

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/model/Invitation.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/model/Invitation.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Format, Json, Reads, __}
 import uk.gov.hmrc.agentclientrelationships.model.transitional.StatusChangeEvent
 import uk.gov.hmrc.agentmtdidentifiers.model.ClientIdentifier.ClientId
 import uk.gov.hmrc.agentmtdidentifiers.model.Service.{HMRCMTDIT, HMRCMTDITSUPP}
-import uk.gov.hmrc.agentmtdidentifiers.model.{ClientIdType, InvitationId, Service}
+import uk.gov.hmrc.agentmtdidentifiers.model.{InvitationId, Service}
 import uk.gov.hmrc.crypto.json.JsonEncryption.stringEncrypterDecrypter
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/LookupInvitationsControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/LookupInvitationsControllerISpec.scala
@@ -181,19 +181,6 @@ class LookupInvitationsControllerISpec extends BaseControllerISpec {
         result.status shouldBe 200
         result.json shouldBe Json.toJson(Seq(itsaInvitation, suppItsaInvitation))
       }
-      "queried with status that matches some data" in {
-        givenAuditConnector()
-        givenAuthorised()
-
-        await(invitationRepo.collection.insertOne(itsaInvitation).toFuture())
-        await(invitationRepo.collection.insertOne(suppItsaInvitation).toFuture())
-        await(invitationRepo.collection.insertOne(acceptedItsaInvitation).toFuture())
-
-        val result = doGetRequest(invitationsUrl + s"?status=$Accepted")
-
-        result.status shouldBe 200
-        result.json shouldBe Json.toJson(Seq(acceptedItsaInvitation))
-      }
       "queried with multiple params that match some data" in {
         givenAuditConnector()
         givenAuthorised()


### PR DESCRIPTION
The change now means the findByAll func will not query the database if neither ARN or clientId is provided. That type of query is not appropriate for this func and its consumers as there should always be a user-specific identifier.