### PR TITLE
APB-11960-2

### DIFF
--- a/app/uk/gov/hmrc/agentclientrelationships/repository/RelationshipCopyRecordRepository.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/repository/RelationshipCopyRecordRepository.scala
@@ -172,13 +172,9 @@ with RequestAwareLogging {
   )(implicit requestHeader: RequestHeader): Future[Done] = Mdc.preservingMdc {
     if (Seq(MtdIt.enrolmentKey, MtdItSupp.enrolmentKey).contains(enrolmentKey.service))
       findBy(arn, enrolmentKey).flatMap {
-        case Some(record) if !(record.syncToESStatus.contains(Failed) && record.syncToETMPStatus.contains(Failed)) => Future.successful(Done)
-        case optRecord =>
-          logger.warn(s"[backfillItsaCopyRecord] Backfilling completed copy record for $arn and ${enrolmentKey.tag}" +
-            (if (optRecord.isDefined)
-               " there is an existing fully failed record"
-             else
-               ""))
+        case Some(record) if record.syncToESStatus.contains(Success) && record.syncToETMPStatus.contains(Success) => Future.successful(Done)
+        case _ =>
+          logger.warn(s"[backfillItsaCopyRecord] Backfilling completed copy record for $arn and ${enrolmentKey.tag}")
           create(RelationshipCopyRecord(
             arn = arn.value,
             enrolmentKey = enrolmentKey,

--- a/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/CreateRelationshipsService.scala
@@ -68,8 +68,6 @@ extends RequestAwareLogging {
       auditData.set(enrolmentDelegatedKey, false)
       auditData.set(etmpRelationshipCreatedKey, false)
 
-      val isItsa = Seq(MtdIt.enrolmentKey, MtdItSupp.enrolmentKey).contains(enrolmentKey.service)
-
       def createRelationshipRecord: Future[Done] = {
         if (isCopyAcross) {
           val record = RelationshipCopyRecord(
@@ -101,7 +99,7 @@ extends RequestAwareLogging {
         )
         _ = auditService.sendCreateRelationshipAuditEvent()
         _ =
-          if (isItsa && !isCopyAcross)
+          if (!isCopyAcross)
             relationshipCopyRepository.backfillItsaCopyRecord(enrolmentKey, arn) // Done separately to avoid conflicts with copy across retry logic
       } yield Done
     }
@@ -145,7 +143,7 @@ extends RequestAwareLogging {
         _ <- updateEtmpSyncStatus(Success)
       } yield Done
     ).recoverWith {
-      case ex =>
+      case ex if !ex.getMessage.contains("Copy record backfilled to prevent further errors.") =>
         logger.warn(s"[CreateRelationshipsService] Creating ETMP record failed for ${arn.value}, $enrolmentKey due to: ${ex.getMessage}")
         updateEtmpSyncStatus(Failed).map(_ => throw ex)
     }

--- a/app/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipsService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/DeleteRelationshipsService.scala
@@ -69,7 +69,8 @@ extends RequestAwareLogging {
     arn: Arn,
     enrolmentKey: EnrolmentKey,
     suppliedClientId: TaxIdentifier, // Required for invitation cleanup code as the ID provided by users is not always the ID on the enrolment (e.g. ITSA)
-    affinityGroup: Option[AffinityGroup]
+    affinityGroup: Option[AffinityGroup],
+    backfillCopyRecord: Boolean = true
   )(implicit
     request: RequestHeader,
     currentUser: CurrentUser,
@@ -103,7 +104,9 @@ extends RequestAwareLogging {
               suppliedClientId.value,
               endedBy.getOrElse("HMRC")
             )
-            _ = copyRecordRepository.backfillItsaCopyRecord(enrolmentKey, arn) // Creates copy record if enrolment is itsa and doesn't already exist.
+            _ =
+              if (backfillCopyRecord)
+                copyRecordRepository.backfillItsaCopyRecord(enrolmentKey, arn) // Creates copy record if enrolment is itsa and doesn't already exist.
           } yield {
             if (enrolmentDeallocated || etmpRelationshipRemoved)
               true

--- a/app/uk/gov/hmrc/agentclientrelationships/services/ItsaDeauthAndCleanupService.scala
+++ b/app/uk/gov/hmrc/agentclientrelationships/services/ItsaDeauthAndCleanupService.scala
@@ -100,7 +100,8 @@ class ItsaDeauthAndCleanupService @Inject() (
                         arn = Arn(arn),
                         enrolmentKey = EnrolmentKey(serviceToCheck, MtdItId(mtdItId)),
                         suppliedClientId = NinoWithoutSuffix(nino),
-                        affinityGroup = currentUser.affinityGroup
+                        affinityGroup = currentUser.affinityGroup,
+                        backfillCopyRecord = false
                       )
                       .map(_ => true)
                   case _ => Future.successful(false)

--- a/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSABehaviours.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/controllers/RelationshipsControllerITSABehaviours.scala
@@ -882,6 +882,59 @@ trait RelationshipsControllerITSABehaviours {
         val result = doRequest
         result.status shouldBe 401
       }
+
+      "return 404 after backfilling new copy across record when there is a mapping present, but no copy across record and the agent is authorised for ITSA-SUPP" in {
+        givenPrincipalAgentUser(arn, "foo")
+        givenGroupInfo("foo", "bar")
+        givenAdminUser("foo", "any")
+        givenUserIsSubscribedAgent(
+          arn,
+          withThisGroupId = "foo",
+          withThisGgUserId = "any",
+          withThisAgentCode = "bar"
+        )
+
+        givenDelegatedGroupIdsNotExistFor(mtdItEnrolmentKey)
+        givenDelegatedGroupIdsNotExistFor(mtdItSuppEnrolmentKey)
+
+        givenNinoIsKnownFor(mtdItId, nino)
+        givenMtdItIdIsKnownFor(nino, mtdItId)
+        givenArnIsKnownFor(arn, SaAgentReference("foo"))
+        givenClientHasRelationshipWithAgentInCESA(nino, "foo")
+
+        await(relationshipCopyRecordRepository.findBy(arn, mtdItEnrolmentKey)) shouldBe None
+
+        stubFor(post(urlEqualTo(s"/etmp/RESTAdapter/rosm/agent-relationship"))
+          .withRequestBody(containing("0001"))
+          .willReturn(
+            aResponse()
+              .withStatus(422)
+              .withBody(s"""{"reason": "Incorrect Relationship Authorisation Profile"}""")
+          ))
+
+        HipStub.getAllActiveRelationshipsViaClient(
+          mtdItId,
+          arn,
+          activeOnly = true,
+          authProfile = Some("ITSAS001")
+        )
+
+        givenMTDITEnrolmentAllocationSucceeds(mtdItId, "bar")
+
+        val result = doGetRequest(
+          s"/agent-client-relationships/agent/${arn.value}/service/HMRC-MTD-IT/client/MTDITID/${mtdItId.value}"
+        )
+
+        result.status shouldBe 404
+
+        await(relationshipCopyRecordRepository.findBy(arn, mtdItEnrolmentKey)).get should have(
+          Symbol("arn")(arn.value),
+          Symbol("enrolmentKey")(mtdItEnrolmentKey),
+          Symbol("references")(None),
+          Symbol("syncToETMPStatus")(Some(SyncStatus.Success)),
+          Symbol("syncToESStatus")(Some(SyncStatus.Success))
+        )
+      }
     }
   }
 }

--- a/it/test/uk/gov/hmrc/agentclientrelationships/repository/RelationshipCopyRecordRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/agentclientrelationships/repository/RelationshipCopyRecordRepositoryISpec.scala
@@ -125,13 +125,13 @@ extends BaseISpec {
       result.syncToESStatus shouldBe Some(SyncStatus.Success)
     }
 
-    "not overwrite an existing ITSA copy record when backfilling" in {
+    "not overwrite an existing completed ITSA copy record when backfilling" in {
       val existing = RelationshipCopyRecord(
         arn = arn.value,
         enrolmentKey = mtdItEnrolmentKey,
         dateTime = now.minusDays(1),
-        syncToETMPStatus = Some(SyncStatus.Failed),
-        syncToESStatus = Some(SyncStatus.InProgress)
+        syncToETMPStatus = Some(SyncStatus.Success),
+        syncToESStatus = Some(SyncStatus.Success)
       )
 
       await(repo.create(existing))

--- a/test/uk/gov/hmrc/agentclientrelationships/mocks/MockDeleteRelationshipsService.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/mocks/MockDeleteRelationshipsService.scala
@@ -47,7 +47,8 @@ trait MockDeleteRelationshipsService {
       eqs(arn),
       eqs(enrolment),
       eqs(suppliedClientId),
-      eqs(affinityGroup)
+      eqs(affinityGroup),
+      any[Boolean]
     )(
       any[RequestHeader],
       any[CurrentUser],

--- a/test/uk/gov/hmrc/agentclientrelationships/services/ItsaDeauthAndCleanupServiceSpec.scala
+++ b/test/uk/gov/hmrc/agentclientrelationships/services/ItsaDeauthAndCleanupServiceSpec.scala
@@ -163,7 +163,8 @@ with MockAuditService {
           any[Arn],
           any[EnrolmentKey],
           any[TaxIdentifier],
-          any[Option[AffinityGroup]]
+          any[Option[AffinityGroup]],
+          any[Boolean]
         )(
           any[RequestHeader],
           any[CurrentUser],
@@ -225,7 +226,8 @@ with MockAuditService {
           any[Arn],
           any[EnrolmentKey],
           any[TaxIdentifier],
-          any[Option[AffinityGroup]]
+          any[Option[AffinityGroup]],
+          any[Boolean]
         )(
           any[RequestHeader],
           any[CurrentUser],
@@ -271,7 +273,8 @@ with MockAuditService {
           any[Arn],
           any[EnrolmentKey],
           any[TaxIdentifier],
-          any[Option[AffinityGroup]]
+          any[Option[AffinityGroup]],
+          any[Boolean]
         )(
           any[RequestHeader],
           any[CurrentUser],


### PR DESCRIPTION
Logic updated to ensure backfilled copy record is not overridden by recovery behaviour. Also made backfill only ignore existing fully completed copy records.
Additionally, updated cleanup logic for agents switching from main to supp relationships from triggering backfill logic in case it interferes.